### PR TITLE
feat: create mock trading backend api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+PORT=4000
+MONGO_URI=mongodb://localhost:27017/mocktrading
+JWT_SECRET=supersecret

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+uploads

--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+# Mock Trading Backend API
+
+A complete Express.js + MongoDB backend for a mock trading application supporting authentication, market data, watchlists, orders, trades, portfolio, funds management, and admin monitoring. Includes a Socket.IO server that simulates live price streaming for subscribed instruments.
+
+## Getting Started
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Copy the environment template and update values as needed:
+
+```bash
+cp .env.example .env
+```
+
+3. Start the development server:
+
+```bash
+npm run dev
+```
+
+The API will run on `http://localhost:4000` by default and expose all routes under `/api`.
+
+## API Overview
+
+- `POST /api/auth/register` – Create a new user account.
+- `POST /api/auth/login` – Authenticate and obtain a JWT token.
+- `GET /api/market/instruments?search=...` – Search for instruments by symbol, name, or ISIN.
+- `POST /api/market/instruments/import` – Admin CSV import for the instrument master.
+- `GET /api/market/live/:symbol` – Retrieve the latest simulated price for a symbol.
+- `POST /api/watchlist` – Add an instrument to the authenticated user's watchlist.
+- `GET /api/watchlist` – Fetch the authenticated user's watchlist entries.
+- `DELETE /api/watchlist/:id` – Remove an instrument from the watchlist.
+- `POST /api/orders` – Place a mock buy or sell order (immediately executed in the simulator).
+- `PUT /api/orders/:id` – Modify a pending order.
+- `DELETE /api/orders/:id` – Cancel an existing order.
+- `GET /api/orders` – List the authenticated user's orders.
+- `GET /api/trades` – Retrieve the authenticated user's trade history.
+- `GET /api/portfolio/holdings` – Current holdings with mark-to-market data.
+- `GET /api/portfolio/positions` – Open positions derived from holdings.
+- `GET /api/portfolio/pnl` – Profit and loss summary (realised/unrealised).
+- `GET /api/account/funds` – Fetch the user's virtual funds balance.
+- `POST /api/account/funds/add` – Add virtual funds and log a transaction.
+- `GET /api/account/transactions` – List funds transactions.
+- `GET /api/admin/users` – Admin list of users.
+- `PUT /api/admin/users/:id/block` – Toggle block state of a user.
+- `GET /api/admin/monitor/orders` – Overview of recent orders and trades.
+
+## WebSocket Streaming
+
+The Socket.IO server exposes a lightweight streaming channel. Connect to the Socket.IO endpoint and emit `subscribe` with a symbol (e.g. `"AAPL"`) to receive `price:update` events every two seconds. Emit `unsubscribe` to stop receiving updates.
+
+## CSV Instrument Import
+
+The admin CSV import endpoint accepts files with headers matching typical broker dumps (e.g. `symbol`, `tradingsymbol`, `lot_size`, `tick_size`, etc.). Data is normalized and upserted into MongoDB.
+
+## Error Handling
+
+The API returns:
+
+- `401` for missing/invalid authentication tokens.
+- `403` when blocked users or non-admins access protected resources.
+- `404` for missing resources.
+- `400` with validation error details.
+
+Global error and not-found handlers ensure consistent JSON responses.
+
+## Mock Trading Logic
+
+Orders are executed immediately using the latest instrument price (or submitted price) and update holdings, trades, and the virtual funds ledger. The design keeps logic modular via controllers, services, and Mongoose models for easy extension with real broker integrations in the future.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "mock-trading-backend",
+  "version": "1.0.0",
+  "description": "Mock trading backend API built with Express and MongoDB",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "nodemon src/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "csv-parse": "^5.5.2",
+    "dotenv": "^16.4.5",
+    "express": "^4.18.3",
+    "express-validator": "^7.0.1",
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^8.3.5",
+    "morgan": "^1.10.0",
+    "multer": "^1.4.5-lts.1",
+    "socket.io": "^4.7.5"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.0"
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const cors = require('cors');
+const morgan = require('morgan');
+const routes = require('./routes');
+const { notFound, errorHandler } = require('./middleware/errorHandler');
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(morgan('dev'));
+
+app.get('/', (req, res) => {
+  res.json({ message: 'Mock Trading API is running' });
+});
+
+app.use('/api', routes);
+app.use(notFound);
+app.use(errorHandler);
+
+module.exports = app;

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+const connectDatabase = async (mongoUri) => {
+  try {
+    await mongoose.connect(mongoUri, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+    console.log('MongoDB connected');
+  } catch (error) {
+    console.error('MongoDB connection error:', error.message);
+    process.exit(1);
+  }
+};
+
+module.exports = connectDatabase;

--- a/src/controllers/accountController.js
+++ b/src/controllers/accountController.js
@@ -1,0 +1,38 @@
+const { validationResult } = require('express-validator');
+const Transaction = require('../models/Transaction');
+
+exports.getFunds = (req, res) => {
+  res.json({ balance: req.user.fundsBalance });
+};
+
+exports.addFunds = async (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const { amount } = req.body;
+    req.user.fundsBalance += amount;
+    await req.user.save();
+    const transaction = await Transaction.create({
+      user: req.user._id,
+      type: 'ADD_FUNDS',
+      amount,
+      balanceAfter: req.user.fundsBalance,
+      description: 'Virtual funds added',
+    });
+    res.status(201).json({ balance: req.user.fundsBalance, transaction });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.getTransactions = async (req, res, next) => {
+  try {
+    const transactions = await Transaction.find({ user: req.user._id }).sort({ createdAt: -1 });
+    res.json(transactions);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -1,0 +1,36 @@
+const User = require('../models/User');
+const Order = require('../models/Order');
+const Trade = require('../models/Trade');
+
+exports.listUsers = async (req, res, next) => {
+  try {
+    const users = await User.find().select('-password');
+    res.json(users);
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.toggleBlockUser = async (req, res, next) => {
+  try {
+    const user = await User.findById(req.params.id);
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    user.isBlocked = !user.isBlocked;
+    await user.save();
+    res.json({ message: user.isBlocked ? 'User blocked' : 'User unblocked', user });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.monitorOrders = async (req, res, next) => {
+  try {
+    const orders = await Order.find().populate('instrument user').sort({ createdAt: -1 }).limit(100);
+    const trades = await Trade.find().populate('instrument user order').sort({ createdAt: -1 }).limit(100);
+    res.json({ orders, trades });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,0 +1,61 @@
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const { validationResult } = require('express-validator');
+const User = require('../models/User');
+
+const generateToken = (user) =>
+  jwt.sign({ id: user._id, role: user.role }, process.env.JWT_SECRET, { expiresIn: '12h' });
+
+exports.register = async (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const { name, email, password } = req.body;
+    const existingUser = await User.findOne({ email });
+    if (existingUser) {
+      return res.status(409).json({ message: 'Email already registered' });
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+    const user = await User.create({ name, email, password: hashedPassword });
+    const token = generateToken(user);
+    res.status(201).json({ token, user: { id: user._id, name: user.name, email: user.email } });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.login = async (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const { email, password } = req.body;
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const token = generateToken(user);
+    res.json({ token, user: { id: user._id, name: user.name, email: user.email, role: user.role } });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.getProfile = async (req, res, next) => {
+  try {
+    const user = await User.findById(req.user._id).select('-password');
+    res.json(user);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/controllers/marketController.js
+++ b/src/controllers/marketController.js
@@ -1,0 +1,104 @@
+const fs = require('fs');
+const { parse } = require('csv-parse');
+const Instrument = require('../models/Instrument');
+
+const safeRemove = (path) => {
+  if (fs.existsSync(path)) {
+    fs.unlinkSync(path);
+  }
+};
+
+exports.searchInstruments = async (req, res, next) => {
+  try {
+    const { search } = req.query;
+    const query = search
+      ? {
+          $or: [
+            { symbol: new RegExp(search, 'i') },
+            { name: new RegExp(search, 'i') },
+            { isin: new RegExp(search, 'i') },
+          ],
+        }
+      : {};
+    const instruments = await Instrument.find(query).limit(50);
+    res.json(instruments);
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.getLivePrice = async (req, res, next) => {
+  try {
+    const { symbol } = req.params;
+    const instrument = await Instrument.findOne({ symbol: symbol.toUpperCase() });
+    if (!instrument) {
+      return res.status(404).json({ message: 'Instrument not found' });
+    }
+    const change = (Math.random() - 0.5) * 2;
+    instrument.lastPrice = Math.max(0, instrument.lastPrice + change);
+    instrument.dailyChange = change;
+    await instrument.save();
+    res.json({ symbol: instrument.symbol, lastPrice: instrument.lastPrice, change });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.importInstruments = async (req, res, next) => {
+  if (!req.file) {
+    return res.status(400).json({ message: 'CSV file is required' });
+  }
+
+  const filePath = req.file.path;
+  const instruments = [];
+
+  const parser = fs
+    .createReadStream(filePath)
+    .pipe(
+      parse({
+        columns: true,
+        skip_empty_lines: true,
+        trim: true,
+      })
+    );
+
+  parser.on('data', (row) => {
+    instruments.push({
+      symbol: (row.symbol || row.tradingsymbol || '').toUpperCase(),
+      name: row.name || row.description || row.symbol,
+      exchange: row.exchange || row.exch,
+      segment: row.segment,
+      instrumentType: row.instrument_type || row.instrumentType,
+      lotSize: Number(row.lot_size || row.lotsize || 1),
+      tickSize: Number(row.tick_size || row.ticksize || 0.05),
+      isin: row.isin,
+      lastPrice: Number(row.last_price || row.ltp || 0),
+    });
+  });
+
+  parser.on('error', (err) => {
+    safeRemove(filePath);
+    next(err);
+  });
+
+  parser.on('end', async () => {
+    safeRemove(filePath);
+    try {
+      const bulkOps = instruments
+        .filter((inst) => inst.symbol)
+        .map((inst) => ({
+          updateOne: {
+            filter: { symbol: inst.symbol },
+            update: { $set: inst },
+            upsert: true,
+          },
+        }));
+      if (bulkOps.length) {
+        await Instrument.bulkWrite(bulkOps);
+      }
+      res.json({ message: `Imported ${bulkOps.length} instruments` });
+    } catch (error) {
+      next(error);
+    }
+  });
+};

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -1,0 +1,75 @@
+const { validationResult } = require('express-validator');
+const Order = require('../models/Order');
+const Trade = require('../models/Trade');
+const { executeOrder } = require('../services/orderService');
+
+exports.placeOrder = async (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const result = await executeOrder(req.user, req.body);
+    res.status(201).json({ order: result.order, trade: result.trade });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.modifyOrder = async (req, res, next) => {
+  try {
+    const order = await Order.findOne({ _id: req.params.id, user: req.user._id });
+    if (!order) {
+      return res.status(404).json({ message: 'Order not found' });
+    }
+    if (order.status !== 'PENDING') {
+      return res.status(400).json({ message: 'Only pending orders can be modified' });
+    }
+    const updates = ['quantity', 'price', 'validity', 'notes'];
+    updates.forEach((field) => {
+      if (req.body[field] !== undefined) {
+        order[field] = req.body[field];
+      }
+    });
+    await order.save();
+    res.json(order);
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.cancelOrder = async (req, res, next) => {
+  try {
+    const order = await Order.findOne({ _id: req.params.id, user: req.user._id });
+    if (!order) {
+      return res.status(404).json({ message: 'Order not found' });
+    }
+    if (order.status === 'CANCELLED') {
+      return res.status(400).json({ message: 'Order already cancelled' });
+    }
+    order.status = 'CANCELLED';
+    await order.save();
+    res.json({ message: 'Order cancelled', order });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.getOrders = async (req, res, next) => {
+  try {
+    const orders = await Order.find({ user: req.user._id }).populate('instrument');
+    res.json(orders);
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.getTrades = async (req, res, next) => {
+  try {
+    const trades = await Trade.find({ user: req.user._id }).populate('instrument order');
+    res.json(trades);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/controllers/portfolioController.js
+++ b/src/controllers/portfolioController.js
@@ -1,0 +1,83 @@
+const Holding = require('../models/Holding');
+const Instrument = require('../models/Instrument');
+const Trade = require('../models/Trade');
+
+const mapHoldingWithInstrument = async (holdings) => {
+  const instrumentIds = holdings.map((h) => h.instrument);
+  const instruments = await Instrument.find({ _id: { $in: instrumentIds } });
+  const instrumentMap = instruments.reduce((acc, inst) => {
+    acc[inst._id.toString()] = inst;
+    return acc;
+  }, {});
+
+  return holdings.map((holding) => {
+    const instrument = instrumentMap[holding.instrument.toString()];
+    const markPrice = instrument?.lastPrice || holding.averagePrice;
+    const pnl = (markPrice - holding.averagePrice) * holding.quantity;
+    return {
+      id: holding._id,
+      instrument,
+      quantity: holding.quantity,
+      averagePrice: holding.averagePrice,
+      markPrice,
+      pnl,
+    };
+  });
+};
+
+exports.getHoldings = async (req, res, next) => {
+  try {
+    const holdings = await Holding.find({ user: req.user._id });
+    const enriched = await mapHoldingWithInstrument(holdings);
+    res.json(enriched);
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.getPositions = async (req, res, next) => {
+  try {
+    const holdings = await Holding.find({ user: req.user._id });
+    const enriched = await mapHoldingWithInstrument(holdings);
+    const positions = enriched
+      .filter((item) => item.quantity !== 0)
+      .map((item) => ({
+        instrument: item.instrument,
+        side: item.quantity >= 0 ? 'LONG' : 'SHORT',
+        quantity: Math.abs(item.quantity),
+        averagePrice: item.averagePrice,
+        markPrice: item.markPrice,
+        pnl: item.pnl,
+      }));
+    res.json(positions);
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.getPnlSummary = async (req, res, next) => {
+  try {
+    const holdings = await Holding.find({ user: req.user._id });
+    const enriched = await mapHoldingWithInstrument(holdings);
+    const realized = await Trade.aggregate([
+      { $match: { user: req.user._id } },
+      {
+        $group: {
+          _id: '$side',
+          amount: { $sum: { $multiply: ['$quantity', '$price'] } },
+        },
+      },
+    ]);
+    const realizedMap = realized.reduce((acc, item) => {
+      acc[item._id] = item.amount;
+      return acc;
+    }, {});
+    const invested = enriched.reduce((sum, item) => sum + item.averagePrice * item.quantity, 0);
+    const currentValue = enriched.reduce((sum, item) => sum + item.markPrice * item.quantity, 0);
+    const unrealized = currentValue - invested;
+    const realizedPnl = (realizedMap.SELL || 0) - (realizedMap.BUY || 0);
+    res.json({ invested, currentValue, unrealized, realized: realizedPnl, total: unrealized + realizedPnl });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/controllers/watchlistController.js
+++ b/src/controllers/watchlistController.js
@@ -1,0 +1,47 @@
+const { validationResult } = require('express-validator');
+const Instrument = require('../models/Instrument');
+const WatchlistItem = require('../models/WatchlistItem');
+
+exports.addToWatchlist = async (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const { symbol } = req.body;
+    const instrument = await Instrument.findOne({ symbol: symbol.toUpperCase() });
+    if (!instrument) {
+      return res.status(404).json({ message: 'Instrument not found' });
+    }
+
+    const item = await WatchlistItem.create({ user: req.user._id, instrument: instrument._id });
+    res.status(201).json(item);
+  } catch (error) {
+    if (error.code === 11000) {
+      return res.status(409).json({ message: 'Instrument already in watchlist' });
+    }
+    next(error);
+  }
+};
+
+exports.removeFromWatchlist = async (req, res, next) => {
+  try {
+    const deleted = await WatchlistItem.findOneAndDelete({ _id: req.params.id, user: req.user._id });
+    if (!deleted) {
+      return res.status(404).json({ message: 'Watchlist item not found' });
+    }
+    res.json({ message: 'Removed from watchlist' });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.getWatchlist = async (req, res, next) => {
+  try {
+    const watchlist = await WatchlistItem.find({ user: req.user._id }).populate('instrument');
+    res.json(watchlist);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,0 +1,35 @@
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+const auth = async (req, res, next) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Authentication required' });
+  }
+
+  const token = authHeader.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const user = await User.findById(decoded.id);
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid token' });
+    }
+    if (user.isBlocked) {
+      return res.status(403).json({ message: 'Account is blocked' });
+    }
+    req.user = user;
+    next();
+  } catch (error) {
+    console.error('Auth error:', error);
+    res.status(401).json({ message: 'Invalid token' });
+  }
+};
+
+const authorizeAdmin = (req, res, next) => {
+  if (req.user.role !== 'admin') {
+    return res.status(403).json({ message: 'Admin access required' });
+  }
+  next();
+};
+
+module.exports = { auth, authorizeAdmin };

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,0 +1,15 @@
+const notFound = (req, res, next) => {
+  res.status(404).json({ message: 'Resource not found' });
+};
+
+const errorHandler = (err, req, res, next) => {
+  console.error(err);
+  if (res.headersSent) {
+    return next(err);
+  }
+  const status = err.status || 500;
+  const message = err.message || 'Internal Server Error';
+  res.status(status).json({ message });
+};
+
+module.exports = { notFound, errorHandler };

--- a/src/models/Holding.js
+++ b/src/models/Holding.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const holdingSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    instrument: { type: mongoose.Schema.Types.ObjectId, ref: 'Instrument', required: true },
+    quantity: { type: Number, required: true, default: 0 },
+    averagePrice: { type: Number, required: true, default: 0 },
+  },
+  { timestamps: true }
+);
+
+holdingSchema.index({ user: 1, instrument: 1 }, { unique: true });
+
+module.exports = mongoose.model('Holding', holdingSchema);

--- a/src/models/Instrument.js
+++ b/src/models/Instrument.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const instrumentSchema = new mongoose.Schema(
+  {
+    symbol: { type: String, required: true, unique: true, uppercase: true },
+    name: { type: String, required: true },
+    exchange: { type: String },
+    segment: { type: String },
+    instrumentType: { type: String },
+    lotSize: { type: Number, default: 1 },
+    tickSize: { type: Number, default: 0.05 },
+    isin: { type: String },
+    lastPrice: { type: Number, default: 0 },
+    dailyChange: { type: Number, default: 0 },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Instrument', instrumentSchema);

--- a/src/models/Order.js
+++ b/src/models/Order.js
@@ -1,0 +1,35 @@
+const mongoose = require('mongoose');
+
+const orderSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    instrument: { type: mongoose.Schema.Types.ObjectId, ref: 'Instrument', required: true },
+    side: { type: String, enum: ['BUY', 'SELL'], required: true },
+    quantity: { type: Number, required: true },
+    price: { type: Number, required: true },
+    status: {
+      type: String,
+      enum: ['PENDING', 'COMPLETED', 'CANCELLED'],
+      default: 'COMPLETED',
+    },
+    orderType: {
+      type: String,
+      enum: ['MARKET', 'LIMIT'],
+      default: 'MARKET',
+    },
+    productType: {
+      type: String,
+      enum: ['CNC', 'MIS', 'NRML'],
+      default: 'CNC',
+    },
+    validity: {
+      type: String,
+      enum: ['DAY', 'IOC', 'GTC'],
+      default: 'DAY',
+    },
+    notes: { type: String },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Order', orderSchema);

--- a/src/models/Position.js
+++ b/src/models/Position.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+
+const positionSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    instrument: { type: mongoose.Schema.Types.ObjectId, ref: 'Instrument', required: true },
+    side: { type: String, enum: ['LONG', 'SHORT'], required: true },
+    quantity: { type: Number, required: true },
+    averagePrice: { type: Number, required: true },
+    markPrice: { type: Number, required: true },
+    pnl: { type: Number, required: true },
+  },
+  { timestamps: true }
+);
+
+positionSchema.index({ user: 1, instrument: 1 }, { unique: true });
+
+module.exports = mongoose.model('Position', positionSchema);

--- a/src/models/Trade.js
+++ b/src/models/Trade.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+const tradeSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    order: { type: mongoose.Schema.Types.ObjectId, ref: 'Order', required: true },
+    instrument: { type: mongoose.Schema.Types.ObjectId, ref: 'Instrument', required: true },
+    side: { type: String, enum: ['BUY', 'SELL'], required: true },
+    quantity: { type: Number, required: true },
+    price: { type: Number, required: true },
+    tradeTime: { type: Date, default: Date.now },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Trade', tradeSchema);

--- a/src/models/Transaction.js
+++ b/src/models/Transaction.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const transactionSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    type: { type: String, enum: ['ADD_FUNDS', 'DEBIT', 'CREDIT'], required: true },
+    amount: { type: Number, required: true },
+    balanceAfter: { type: Number, required: true },
+    description: { type: String },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Transaction', transactionSchema);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const userSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    email: { type: String, required: true, unique: true, lowercase: true },
+    password: { type: String, required: true },
+    role: { type: String, enum: ['user', 'admin'], default: 'user' },
+    isBlocked: { type: Boolean, default: false },
+    fundsBalance: { type: Number, default: 0 },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('User', userSchema);

--- a/src/models/WatchlistItem.js
+++ b/src/models/WatchlistItem.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const watchlistItemSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    instrument: { type: mongoose.Schema.Types.ObjectId, ref: 'Instrument', required: true },
+  },
+  { timestamps: true }
+);
+
+watchlistItemSchema.index({ user: 1, instrument: 1 }, { unique: true });
+
+module.exports = mongoose.model('WatchlistItem', watchlistItemSchema);

--- a/src/routes/accountRoutes.js
+++ b/src/routes/accountRoutes.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const { body } = require('express-validator');
+const { auth } = require('../middleware/auth');
+const accountController = require('../controllers/accountController');
+
+const router = express.Router();
+
+router.get('/funds', auth, accountController.getFunds);
+router.post(
+  '/funds/add',
+  auth,
+  [body('amount').isFloat({ min: 1 }).withMessage('Amount must be at least 1')],
+  accountController.addFunds
+);
+router.get('/transactions', auth, accountController.getTransactions);
+
+module.exports = router;

--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const { auth, authorizeAdmin } = require('../middleware/auth');
+const adminController = require('../controllers/adminController');
+
+const router = express.Router();
+
+router.use(auth, authorizeAdmin);
+router.get('/users', adminController.listUsers);
+router.put('/users/:id/block', adminController.toggleBlockUser);
+router.get('/monitor/orders', adminController.monitorOrders);
+
+module.exports = router;

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const { body } = require('express-validator');
+const authController = require('../controllers/authController');
+const { auth } = require('../middleware/auth');
+
+const router = express.Router();
+
+router.post(
+  '/register',
+  [
+    body('name').notEmpty().withMessage('Name is required'),
+    body('email').isEmail().withMessage('Valid email is required'),
+    body('password').isLength({ min: 6 }).withMessage('Password must be at least 6 characters'),
+  ],
+  authController.register
+);
+
+router.post(
+  '/login',
+  [
+    body('email').isEmail().withMessage('Valid email is required'),
+    body('password').notEmpty().withMessage('Password is required'),
+  ],
+  authController.login
+);
+
+router.get('/me', auth, authController.getProfile);
+
+module.exports = router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const authRoutes = require('./authRoutes');
+const marketRoutes = require('./marketRoutes');
+const watchlistRoutes = require('./watchlistRoutes');
+const orderRoutes = require('./orderRoutes');
+const tradeRoutes = require('./tradeRoutes');
+const portfolioRoutes = require('./portfolioRoutes');
+const accountRoutes = require('./accountRoutes');
+const adminRoutes = require('./adminRoutes');
+
+const router = express.Router();
+
+router.use('/auth', authRoutes);
+router.use('/market', marketRoutes);
+router.use('/watchlist', watchlistRoutes);
+router.use('/orders', orderRoutes);
+router.use('/trades', tradeRoutes);
+router.use('/portfolio', portfolioRoutes);
+router.use('/account', accountRoutes);
+router.use('/admin', adminRoutes);
+
+module.exports = router;

--- a/src/routes/marketRoutes.js
+++ b/src/routes/marketRoutes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const multer = require('multer');
+const { auth, authorizeAdmin } = require('../middleware/auth');
+const marketController = require('../controllers/marketController');
+
+const upload = multer({ dest: 'uploads/' });
+const router = express.Router();
+
+router.get('/instruments', marketController.searchInstruments);
+router.get('/live/:symbol', marketController.getLivePrice);
+router.post('/instruments/import', auth, authorizeAdmin, upload.single('file'), marketController.importInstruments);
+
+module.exports = router;

--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const { body } = require('express-validator');
+const { auth } = require('../middleware/auth');
+const orderController = require('../controllers/orderController');
+
+const router = express.Router();
+
+router.post(
+  '/',
+  auth,
+  [
+    body('symbol').notEmpty().withMessage('Symbol is required'),
+    body('side').isIn(['BUY', 'SELL']).withMessage('Side must be BUY or SELL'),
+    body('quantity').isInt({ min: 1 }).withMessage('Quantity must be at least 1'),
+    body('price').optional().isFloat({ min: 0 }).withMessage('Price must be positive'),
+  ],
+  orderController.placeOrder
+);
+router.put('/:id', auth, orderController.modifyOrder);
+router.delete('/:id', auth, orderController.cancelOrder);
+router.get('/', auth, orderController.getOrders);
+
+module.exports = router;

--- a/src/routes/portfolioRoutes.js
+++ b/src/routes/portfolioRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const { auth } = require('../middleware/auth');
+const portfolioController = require('../controllers/portfolioController');
+
+const router = express.Router();
+
+router.get('/holdings', auth, portfolioController.getHoldings);
+router.get('/positions', auth, portfolioController.getPositions);
+router.get('/pnl', auth, portfolioController.getPnlSummary);
+
+module.exports = router;

--- a/src/routes/tradeRoutes.js
+++ b/src/routes/tradeRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { auth } = require('../middleware/auth');
+const orderController = require('../controllers/orderController');
+
+const router = express.Router();
+
+router.get('/', auth, orderController.getTrades);
+
+module.exports = router;

--- a/src/routes/watchlistRoutes.js
+++ b/src/routes/watchlistRoutes.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const { body } = require('express-validator');
+const { auth } = require('../middleware/auth');
+const watchlistController = require('../controllers/watchlistController');
+
+const router = express.Router();
+
+router.post(
+  '/',
+  auth,
+  [body('symbol').notEmpty().withMessage('Symbol is required')],
+  watchlistController.addToWatchlist
+);
+router.delete('/:id', auth, watchlistController.removeFromWatchlist);
+router.get('/', auth, watchlistController.getWatchlist);
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,44 @@
+require('dotenv').config();
+const http = require('http');
+const { Server } = require('socket.io');
+const app = require('./app');
+const connectDatabase = require('./config/database');
+const PriceSimulator = require('./utils/priceSimulator');
+
+const PORT = process.env.PORT || 4000;
+const server = http.createServer(app);
+const io = new Server(server, {
+  cors: {
+    origin: '*',
+  },
+});
+
+const priceSimulator = new PriceSimulator(io);
+priceSimulator.start();
+
+io.on('connection', (socket) => {
+  socket.on('subscribe', (symbol) => {
+    if (symbol) {
+      priceSimulator.subscribe(socket, symbol);
+    }
+  });
+
+  socket.on('unsubscribe', (symbol) => {
+    if (symbol) {
+      priceSimulator.unsubscribe(socket, symbol);
+    }
+  });
+
+  socket.on('disconnect', () => {
+    priceSimulator.removeSocket(socket.id);
+  });
+});
+
+const startServer = async () => {
+  await connectDatabase(process.env.MONGO_URI);
+  server.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+};
+
+startServer();

--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -1,0 +1,130 @@
+const mongoose = require('mongoose');
+const Instrument = require('../models/Instrument');
+const Order = require('../models/Order');
+const Trade = require('../models/Trade');
+const Holding = require('../models/Holding');
+const Transaction = require('../models/Transaction');
+
+const executeOrder = async (user, payload) => {
+  const session = await mongoose.startSession();
+  session.startTransaction();
+  try {
+    const instrument = await Instrument.findOne({ symbol: payload.symbol.toUpperCase() }).session(session);
+    if (!instrument) {
+      const err = new Error('Instrument not found');
+      err.status = 404;
+      throw err;
+    }
+
+    const price = payload.price || instrument.lastPrice || 1;
+    const amount = price * payload.quantity;
+
+    if (payload.side === 'BUY' && user.fundsBalance < amount) {
+      const err = new Error('Insufficient funds');
+      err.status = 400;
+      throw err;
+    }
+
+    const [order] = await Order.create(
+      [
+        {
+          user: user._id,
+          instrument: instrument._id,
+          side: payload.side,
+          quantity: payload.quantity,
+          price,
+          orderType: payload.orderType,
+          productType: payload.productType,
+          validity: payload.validity,
+          notes: payload.notes,
+        },
+      ],
+      { session }
+    );
+
+    const [trade] = await Trade.create(
+      [
+        {
+          user: user._id,
+          order: order._id,
+          instrument: instrument._id,
+          side: payload.side,
+          quantity: payload.quantity,
+          price,
+        },
+      ],
+      { session }
+    );
+
+    let fundsBalance = user.fundsBalance;
+    if (payload.side === 'BUY') {
+      fundsBalance -= amount;
+    } else {
+      fundsBalance += amount;
+    }
+
+    const holding = await Holding.findOne({ user: user._id, instrument: instrument._id }).session(session);
+
+    if (payload.side === 'BUY') {
+      const totalQuantity = (holding ? holding.quantity : 0) + payload.quantity;
+      const totalCost = (holding ? holding.quantity * holding.averagePrice : 0) + amount;
+      if (holding) {
+        holding.quantity = totalQuantity;
+        holding.averagePrice = totalCost / totalQuantity;
+        await holding.save({ session });
+      } else {
+        await Holding.create(
+          [
+            {
+              user: user._id,
+              instrument: instrument._id,
+              quantity: totalQuantity,
+              averagePrice: totalCost / totalQuantity,
+            },
+          ],
+          { session }
+        );
+      }
+    } else if (payload.side === 'SELL') {
+      if (!holding || holding.quantity < payload.quantity) {
+        const err = new Error('Not enough quantity to sell');
+        err.status = 400;
+        throw err;
+      }
+      holding.quantity -= payload.quantity;
+      if (holding.quantity === 0) {
+        await holding.deleteOne({ session });
+      } else {
+        await holding.save({ session });
+      }
+    }
+
+    const transactionType = payload.side === 'BUY' ? 'DEBIT' : 'CREDIT';
+    await Transaction.create(
+      [
+        {
+          user: user._id,
+          type: transactionType,
+          amount,
+          balanceAfter: fundsBalance,
+          description: `${payload.side} ${payload.quantity} ${instrument.symbol} @ ${price}`,
+        },
+      ],
+      { session }
+    );
+
+    user.fundsBalance = fundsBalance;
+    await user.save({ session });
+
+    await session.commitTransaction();
+    session.endSession();
+
+    return { order, trade, instrument };
+  } catch (error) {
+    await session.abortTransaction();
+    session.endSession();
+    throw error;
+  }
+};
+
+module.exports = { executeOrder };

--- a/src/utils/priceSimulator.js
+++ b/src/utils/priceSimulator.js
@@ -1,0 +1,74 @@
+const Instrument = require('../models/Instrument');
+
+class PriceSimulator {
+  constructor(io) {
+    this.io = io;
+    this.interval = null;
+    this.subscriptions = new Map(); // symbol -> Set(socketId)
+  }
+
+  start() {
+    if (this.interval) return;
+    this.interval = setInterval(async () => {
+      const symbols = Array.from(this.subscriptions.keys());
+      if (!symbols.length) {
+        return;
+      }
+
+      const instruments = await Instrument.find({ symbol: { $in: symbols } });
+      instruments.forEach(async (instrument) => {
+        const change = (Math.random() - 0.5) * 2; // random change
+        instrument.lastPrice = Math.max(0, instrument.lastPrice + change);
+        instrument.dailyChange = change;
+        await instrument.save();
+        this.io.to(instrument.symbol).emit('price:update', {
+          symbol: instrument.symbol,
+          lastPrice: instrument.lastPrice,
+          change,
+          time: new Date().toISOString(),
+        });
+      });
+    }, 2000);
+  }
+
+  stop() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  subscribe(socket, symbol) {
+    const upperSymbol = symbol.toUpperCase();
+    if (!this.subscriptions.has(upperSymbol)) {
+      this.subscriptions.set(upperSymbol, new Set());
+    }
+    socket.join(upperSymbol);
+    this.subscriptions.get(upperSymbol).add(socket.id);
+  }
+
+  unsubscribe(socket, symbol) {
+    const upperSymbol = symbol.toUpperCase();
+    if (this.subscriptions.has(upperSymbol)) {
+      const set = this.subscriptions.get(upperSymbol);
+      set.delete(socket.id);
+      socket.leave(upperSymbol);
+      if (!set.size) {
+        this.subscriptions.delete(upperSymbol);
+      }
+    }
+  }
+
+  removeSocket(socketId) {
+    this.subscriptions.forEach((set, symbol) => {
+      if (set.has(socketId)) {
+        set.delete(socketId);
+        if (!set.size) {
+          this.subscriptions.delete(symbol);
+        }
+      }
+    });
+  }
+}
+
+module.exports = PriceSimulator;


### PR DESCRIPTION
## Summary
- set up an Express server with JWT authentication, modular routing, and socket-based price streaming
- add MongoDB models plus controllers for market data, orders, trades, portfolios, funds, and admin workflows
- document environment variables and endpoints in the README for easy setup

## Testing
- not run (node runtime unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d907f05eec8331a35b404bab9ea18a