### PR TITLE
Add admin controls for Zerodha credential automation

### DIFF
--- a/src/models/ZerodhaCredential.js
+++ b/src/models/ZerodhaCredential.js
@@ -1,0 +1,38 @@
+const mongoose = require('mongoose');
+
+const ZerodhaCredentialSchema = new mongoose.Schema({
+  apiKey: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  apiSecret: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  requestToken: {
+    type: String,
+    default: null
+  },
+  accessToken: {
+    type: String,
+    default: null
+  },
+  refreshToken: {
+    type: String,
+    default: null
+  },
+  lastAccessTokenGeneratedAt: {
+    type: Date,
+    default: null
+  },
+  lastRequestTokenAt: {
+    type: Date,
+    default: null
+  }
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('ZerodhaCredential', ZerodhaCredentialSchema);

--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -8,5 +8,9 @@ router.use(auth, authorizeAdmin);
 router.get('/users', adminController.listUsers);
 router.put('/users/:id/block', adminController.toggleBlockUser);
 router.get('/monitor/orders', adminController.monitorOrders);
+router.get('/zerodha/status', adminController.getZerodhaStatus);
+router.post('/zerodha/credentials', adminController.updateZerodhaCredentials);
+router.post('/zerodha/generate-access-token', adminController.generateZerodhaAccessToken);
+router.post('/zerodha/refresh-access-token', adminController.refreshZerodhaAccessToken);
 
 module.exports = router;

--- a/src/services/zerodhaService.js
+++ b/src/services/zerodhaService.js
@@ -1,11 +1,15 @@
 const KiteConnect = require('kiteconnect').KiteConnect;
 const KiteTicker = require('kiteconnect').KiteTicker;
 
+const ZerodhaCredential = require('../models/ZerodhaCredential');
+
 class ZerodhaService {
   constructor() {
-    this.apiKey = 'n9fp8kfh1lcbqnt8';
-    this.apiSecret = '4j9bekkl72yo7wv8h34jtl7mhw9gnvf9';
+    this.apiKey = null;
+    this.apiSecret = null;
     this.accessToken = null;
+    this.refreshToken = null;
+    this.requestToken = null;
     this.kc = null;
     this.ticker = null;
     this.subscribedTokens = new Set();
@@ -14,30 +18,287 @@ class ZerodhaService {
     this.reconnectAttempts = 0;
     this.maxReconnectAttempts = 5;
     this.livePriceCache = new Map();
-    
+    this.restPollingInterval = null;
+    this.restPollingIntervalMs = 60 * 1000;
+    this.isRestPollingInFlight = false;
+    this.refreshTimeout = null;
+    this.nextScheduledRefreshAt = null;
+    this.tickerEventsBound = false;
+    this.credentialRecord = null;
+    this.bootstrapPromise = this.loadPersistedCredentials();
+
     // Market hours: 9:15 AM to 3:30 PM IST (Monday to Friday)
     this.marketStartHour = 9;
     this.marketStartMinute = 15;
     this.marketEndHour = 15;
     this.marketEndMinute = 30;
-    
-    // Initialize KiteConnect
-    this.kc = new KiteConnect({
-      api_key: this.apiKey
-    });
-    
+
     // Check market hours every minute
     setInterval(() => {
       this.checkMarketHours();
     }, 60000);
-    
+
     this.checkMarketHours();
+  }
+
+  async updateCredentials({ apiKey, apiSecret }) {
+    await this.ensureBootstrapComplete();
+
+    if (!apiKey || !apiSecret) {
+      throw new Error('API key and API secret are required');
+    }
+
+    if (this.ticker && this.ticker.connected()) {
+      this.disconnectWebSocket();
+    }
+    this.stopRestPolling();
+
+    this.apiKey = apiKey;
+    this.apiSecret = apiSecret;
+    this.accessToken = null;
+    this.refreshToken = null;
+    this.requestToken = null;
+    this.livePriceCache.clear();
+    this.subscribedTokens.clear();
+    this.priceCallbacks.clear();
+    this.ticker = null;
+    this.tickerEventsBound = false;
+
+    if (this.refreshTimeout) {
+      clearTimeout(this.refreshTimeout);
+      this.refreshTimeout = null;
+    }
+    this.nextScheduledRefreshAt = null;
+
+    this.kc = new KiteConnect({
+      api_key: this.apiKey
+    });
+
+    await this.persistCredentialState({
+      apiKey: this.apiKey,
+      apiSecret: this.apiSecret,
+      requestToken: null,
+      accessToken: null,
+      refreshToken: null,
+      lastRequestTokenAt: null,
+      lastAccessTokenGeneratedAt: null
+    });
+
+    return {
+      message: 'Zerodha API credentials updated successfully'
+    };
+  }
+
+  async persistCredentialState(updates = {}) {
+    await this.ensureBootstrapComplete();
+
+    const doc = this.credentialRecord || new ZerodhaCredential();
+
+    const fields = {
+      apiKey: updates.apiKey !== undefined ? updates.apiKey : this.apiKey,
+      apiSecret: updates.apiSecret !== undefined ? updates.apiSecret : this.apiSecret,
+      requestToken: updates.requestToken !== undefined ? updates.requestToken : this.requestToken,
+      accessToken: updates.accessToken !== undefined ? updates.accessToken : this.accessToken,
+      refreshToken: updates.refreshToken !== undefined ? updates.refreshToken : this.refreshToken,
+      lastRequestTokenAt: updates.lastRequestTokenAt !== undefined ? updates.lastRequestTokenAt : (this.credentialRecord ? this.credentialRecord.lastRequestTokenAt : null),
+      lastAccessTokenGeneratedAt: updates.lastAccessTokenGeneratedAt !== undefined ? updates.lastAccessTokenGeneratedAt : (this.credentialRecord ? this.credentialRecord.lastAccessTokenGeneratedAt : null)
+    };
+
+    Object.entries(fields).forEach(([key, value]) => {
+      doc[key] = value === undefined ? null : value;
+    });
+
+    this.credentialRecord = await doc.save();
+    this.applyCredentialRecord(this.credentialRecord);
+  }
+
+  async refreshAccessToken({ reason = 'manual' } = {}) {
+    await this.ensureBootstrapComplete();
+
+    if (!this.refreshToken) {
+      const error = new Error('Refresh token is not available. Generate a new access token using a request token.');
+      error.status = 400;
+      throw error;
+    }
+
+    if (!this.apiKey || !this.apiSecret) {
+      const error = new Error('Zerodha API credentials are not configured');
+      error.status = 400;
+      throw error;
+    }
+
+    if (!this.kc) {
+      this.kc = new KiteConnect({
+        api_key: this.apiKey
+      });
+    }
+
+    const response = await this.kc.renewAccessToken(this.refreshToken, this.apiSecret);
+
+    this.accessToken = response.access_token;
+    if (response.refresh_token) {
+      this.refreshToken = response.refresh_token;
+    }
+
+    this.kc.setAccessToken(this.accessToken);
+
+    if (this.ticker && this.ticker.connected()) {
+      this.disconnectWebSocket();
+    }
+
+    this.ticker = new KiteTicker({
+      api_key: this.apiKey,
+      access_token: this.accessToken
+    });
+
+    this.tickerEventsBound = false;
+    this.setupTickerEvents();
+
+    if (this.isMarketHours) {
+      this.connectWebSocket();
+    } else {
+      this.startRestPolling();
+    }
+
+    await this.persistCredentialState({
+      accessToken: this.accessToken,
+      refreshToken: this.refreshToken,
+      lastAccessTokenGeneratedAt: new Date()
+    });
+
+    this.scheduleAutoRefresh();
+
+    return {
+      access_token: this.accessToken,
+      refresh_token: this.refreshToken,
+      reason
+    };
+  }
+
+  async getCredentialStatus() {
+    await this.ensureBootstrapComplete();
+
+    const record = this.credentialRecord;
+
+    const nextScheduledRefresh = this.nextScheduledRefreshAt
+      ? new Date(this.nextScheduledRefreshAt)
+      : null;
+
+    return {
+      apiKeyConfigured: Boolean(this.apiKey),
+      accessTokenAvailable: Boolean(this.accessToken),
+      refreshTokenAvailable: Boolean(this.refreshToken),
+      lastRequestTokenAt: record ? record.lastRequestTokenAt : null,
+      lastAccessTokenGeneratedAt: record ? record.lastAccessTokenGeneratedAt : null,
+      nextScheduledRefresh
+    };
+  }
+
+  async loadPersistedCredentials() {
+    try {
+      const credential = await ZerodhaCredential.findOne().sort({ updatedAt: -1 });
+      if (!credential) {
+        return;
+      }
+
+      this.applyCredentialRecord(credential);
+
+      if (this.accessToken) {
+        this.initialize(this.accessToken, { skipPersistence: true });
+      }
+
+      this.scheduleAutoRefresh();
+    } catch (error) {
+      console.error('Failed to load Zerodha credentials:', error);
+    }
+  }
+
+  applyCredentialRecord(credential) {
+    this.credentialRecord = credential;
+    this.apiKey = credential.apiKey;
+    this.apiSecret = credential.apiSecret;
+    this.requestToken = credential.requestToken;
+    this.accessToken = credential.accessToken;
+    this.refreshToken = credential.refreshToken;
+
+    if (this.apiKey) {
+      this.kc = new KiteConnect({
+        api_key: this.apiKey
+      });
+      if (this.accessToken) {
+        this.kc.setAccessToken(this.accessToken);
+      }
+    }
+  }
+
+  async ensureBootstrapComplete() {
+    if (this.bootstrapPromise) {
+      await this.bootstrapPromise;
+      this.bootstrapPromise = null;
+    }
+  }
+
+  scheduleAutoRefresh() {
+    if (this.refreshTimeout) {
+      clearTimeout(this.refreshTimeout);
+      this.refreshTimeout = null;
+    }
+
+    if (!this.apiKey || !this.apiSecret || !this.refreshToken) {
+      this.nextScheduledRefreshAt = null;
+      return;
+    }
+
+    const now = new Date();
+    const nextRun = this.calculateNextRefreshTime(now);
+    const delay = Math.max(nextRun.getTime() - now.getTime(), 0);
+
+    this.nextScheduledRefreshAt = nextRun;
+
+    this.refreshTimeout = setTimeout(async () => {
+      this.refreshTimeout = null;
+      try {
+        await this.refreshAccessToken({ reason: 'scheduled' });
+      } catch (error) {
+        console.error('Scheduled Zerodha access token refresh failed:', error);
+        // Reschedule even after failure to avoid being stuck
+        this.scheduleAutoRefresh();
+      }
+    }, delay);
+  }
+
+  calculateNextRefreshTime(fromDate = new Date()) {
+    const istDate = new Date(fromDate.toLocaleString('en-US', { timeZone: 'Asia/Kolkata' }));
+    const next = new Date(istDate);
+    next.setHours(8, 30, 0, 0);
+
+    if (next <= istDate) {
+      next.setDate(next.getDate() + 1);
+    }
+
+    // Convert back to server timezone
+    const offsetDifference = istDate.getTime() - fromDate.getTime();
+    return new Date(next.getTime() - offsetDifference);
   }
 
   /**
    * Generate login URL for Zerodha authentication
    */
-  getLoginURL() {
+  async getLoginURL() {
+    await this.ensureBootstrapComplete();
+
+    if (!this.apiKey) {
+      const error = new Error('Zerodha API credentials are not configured');
+      error.status = 400;
+      throw error;
+    }
+
+    if (!this.kc) {
+      this.kc = new KiteConnect({
+        api_key: this.apiKey
+      });
+    }
+
     return this.kc.getLoginURL();
   }
 
@@ -45,21 +306,57 @@ class ZerodhaService {
    * Generate access token from request token
    */
   async generateAccessToken(requestToken) {
+    await this.ensureBootstrapComplete();
+
+    if (!this.apiKey || !this.apiSecret) {
+      const error = new Error('Zerodha API credentials are not configured');
+      error.status = 400;
+      throw error;
+    }
+
     try {
+      if (!this.kc) {
+        this.kc = new KiteConnect({
+          api_key: this.apiKey
+        });
+      }
       const response = await this.kc.generateSession(requestToken, this.apiSecret);
       this.accessToken = response.access_token;
+      this.refreshToken = response.refresh_token;
+      this.requestToken = requestToken;
       this.kc.setAccessToken(this.accessToken);
-      
+
       // Initialize ticker with access token
       this.ticker = new KiteTicker({
         api_key: this.apiKey,
         access_token: this.accessToken
       });
-      
+
+      this.tickerEventsBound = false;
       this.setupTickerEvents();
-      
+
+      // Immediately establish a WebSocket connection when market is open
+      // so that live ticks start flowing without waiting for the next
+      // scheduled market-hours check.
+      if (this.isMarketHours) {
+        this.connectWebSocket();
+      } else {
+        this.startRestPolling();
+      }
+
+      await this.persistCredentialState({
+        requestToken,
+        accessToken: this.accessToken,
+        refreshToken: this.refreshToken,
+        lastRequestTokenAt: new Date(),
+        lastAccessTokenGeneratedAt: new Date()
+      });
+
+      this.scheduleAutoRefresh();
+
       return {
         access_token: this.accessToken,
+        refresh_token: this.refreshToken,
         user: response
       };
     } catch (error) {
@@ -71,23 +368,44 @@ class ZerodhaService {
   /**
    * Initialize with existing access token
    */
-  initialize(accessToken) {
+  initialize(accessToken, options = {}) {
+    if (!this.apiKey) {
+      throw new Error('Zerodha API key is not configured');
+    }
+
+    if (!this.kc) {
+      this.kc = new KiteConnect({
+        api_key: this.apiKey
+      });
+    }
+
     this.accessToken = accessToken;
     this.kc.setAccessToken(accessToken);
-    
+
     // Initialize ticker
     this.ticker = new KiteTicker({
       api_key: this.apiKey,
       access_token: this.accessToken
     });
-    
+
+    this.tickerEventsBound = false;
     this.setupTickerEvents();
-    
+
     // Start appropriate price service based on market hours
     if (this.isMarketHours) {
       this.connectWebSocket();
+    } else {
+      this.startRestPolling();
     }
-    
+
+    if (!options.skipPersistence) {
+      this.persistCredentialState({
+        accessToken: this.accessToken
+      }).catch((error) => {
+        console.error('Failed to persist Zerodha initialization state:', error);
+      });
+    }
+
     console.log('Zerodha service initialized with access token');
   }
 
@@ -95,7 +413,9 @@ class ZerodhaService {
    * Setup ticker event handlers
    */
   setupTickerEvents() {
-    if (!this.ticker) return;
+    if (!this.ticker || this.tickerEventsBound) return;
+
+    this.tickerEventsBound = true;
 
     this.ticker.on('ticks', (ticks) => {
       ticks.forEach(tick => {
@@ -130,6 +450,7 @@ class ZerodhaService {
 
     this.ticker.on('disconnect', () => {
       console.log('Zerodha WebSocket disconnected');
+      this.tickerEventsBound = false;
     });
 
     this.ticker.on('error', (error) => {
@@ -138,7 +459,8 @@ class ZerodhaService {
 
     this.ticker.on('close', () => {
       console.log('Zerodha WebSocket connection closed');
-      
+      this.tickerEventsBound = false;
+
       // Attempt to reconnect if market is still open
       if (this.isMarketHours && this.reconnectAttempts < this.maxReconnectAttempts) {
         this.reconnectAttempts++;
@@ -162,9 +484,13 @@ class ZerodhaService {
     
     // Market is closed on weekends
     if (day === 0 || day === 6) {
+      const wasMarketHours = this.isMarketHours;
       this.isMarketHours = false;
       if (this.ticker && this.ticker.connected()) {
         this.disconnectWebSocket();
+      }
+      if (wasMarketHours || !this.restPollingInterval) {
+        this.startRestPolling();
       }
       return;
     }
@@ -180,10 +506,12 @@ class ZerodhaService {
     // Handle market open/close transitions
     if (this.isMarketHours && !wasMarketHours) {
       console.log('Market opened - switching to WebSocket');
+      this.stopRestPolling();
       this.connectWebSocket();
     } else if (!this.isMarketHours && wasMarketHours) {
       console.log('Market closed - switching to REST API');
       this.disconnectWebSocket();
+      this.startRestPolling();
     }
   }
 
@@ -192,8 +520,9 @@ class ZerodhaService {
    */
   connectWebSocket() {
     if (!this.ticker || !this.accessToken) return;
-    
+
     try {
+      this.stopRestPolling();
       if (!this.ticker.connected()) {
         this.ticker.connect();
       }
@@ -209,6 +538,71 @@ class ZerodhaService {
     if (this.ticker && this.ticker.connected()) {
       this.ticker.disconnect();
     }
+    this.tickerEventsBound = false;
+  }
+
+  /**
+   * Start polling live prices via REST when market is closed
+   */
+  startRestPolling() {
+    if (this.isMarketHours) return;
+    if (!this.accessToken) return;
+    if (this.restPollingInterval) return;
+    if (this.subscribedTokens.size === 0) return;
+
+    const executePoll = () => {
+      this.pollRestPrices().catch((error) => {
+        console.error('REST polling failed:', error);
+      });
+    };
+
+    executePoll();
+    this.restPollingInterval = setInterval(executePoll, this.restPollingIntervalMs);
+  }
+
+  /**
+   * Stop REST polling when WebSocket streaming resumes
+   */
+  stopRestPolling() {
+    if (this.restPollingInterval) {
+      clearInterval(this.restPollingInterval);
+      this.restPollingInterval = null;
+    }
+    this.isRestPollingInFlight = false;
+  }
+
+  /**
+   * Poll Zerodha REST API for subscribed tokens and update cache/callbacks
+   */
+  async pollRestPrices() {
+    await this.ensureBootstrapComplete();
+    if (this.isMarketHours) return;
+    if (!this.accessToken) return;
+    if (this.isRestPollingInFlight) return;
+
+    const tokens = Array.from(this.subscribedTokens);
+    if (tokens.length === 0) {
+      return;
+    }
+
+    this.isRestPollingInFlight = true;
+    try {
+      const prices = await this.getLivePriceREST(tokens);
+      Object.values(prices).forEach((price) => {
+        const token = parseInt(price.instrument_token);
+        if (Number.isNaN(token)) return;
+
+        this.livePriceCache.set(token, price);
+        const callback = this.priceCallbacks.get(token);
+        if (callback) {
+          callback(price);
+        }
+      });
+    } catch (error) {
+      console.error('Error polling REST prices:', error);
+    } finally {
+      this.isRestPollingInFlight = false;
+    }
   }
 
   /**
@@ -223,9 +617,9 @@ class ZerodhaService {
       .filter(token => !isNaN(token) && token > 0);
     
     if (validTokens.length === 0) return;
-    
+
     validTokens.forEach(token => this.subscribedTokens.add(token));
-    
+
     if (this.ticker && this.ticker.connected()) {
       try {
         this.ticker.subscribe(validTokens);
@@ -233,6 +627,8 @@ class ZerodhaService {
       } catch (error) {
         console.error('Error subscribing to tokens:', error);
       }
+    } else if (!this.isMarketHours) {
+      this.startRestPolling();
     }
   }
 
@@ -247,7 +643,7 @@ class ZerodhaService {
       .filter(token => !isNaN(token) && token > 0);
     
     validTokens.forEach(token => this.subscribedTokens.delete(token));
-    
+
     if (this.ticker && this.ticker.connected()) {
       try {
         this.ticker.unsubscribe(validTokens);
@@ -255,14 +651,21 @@ class ZerodhaService {
         console.error('Error unsubscribing from tokens:', error);
       }
     }
+
+    if (!this.isMarketHours && this.subscribedTokens.size === 0) {
+      this.stopRestPolling();
+    }
   }
 
   /**
    * Get live price via REST API (for off-market hours)
    */
   async getLivePriceREST(instrumentTokens) {
+    await this.ensureBootstrapComplete();
     if (!this.accessToken) {
-      throw new Error('Access token not provided');
+      const error = new Error('Access token not provided');
+      error.status = 400;
+      throw error;
     }
     
     try {
@@ -303,8 +706,11 @@ class ZerodhaService {
    * Get historical data
    */
   async getHistoricalData(instrumentToken, interval, fromDate, toDate) {
+    await this.ensureBootstrapComplete();
     if (!this.accessToken) {
-      throw new Error('Access token not provided');
+      const error = new Error('Access token not provided');
+      error.status = 400;
+      throw error;
     }
     
     try {
@@ -326,8 +732,11 @@ class ZerodhaService {
    * Get user profile
    */
   async getProfile() {
+    await this.ensureBootstrapComplete();
     if (!this.accessToken) {
-      throw new Error('Access token not provided');
+      const error = new Error('Access token not provided');
+      error.status = 400;
+      throw error;
     }
     
     try {
@@ -368,6 +777,7 @@ class ZerodhaService {
    * Get current price (automatically chooses WebSocket or REST based on market hours)
    */
   async getCurrentPrice(instrumentTokens) {
+    await this.ensureBootstrapComplete();
     const tokens = Array.isArray(instrumentTokens) ? instrumentTokens : [instrumentTokens];
     const validTokens = tokens
       .map(token => parseInt(token))
@@ -417,7 +827,21 @@ class ZerodhaService {
     }
     
     // During off-market hours or WebSocket failure, use REST API
-    return await this.getLivePriceREST(validTokens);
+    const restPrices = await this.getLivePriceREST(validTokens);
+
+    // Update cache and callbacks to keep consumers consistent
+    Object.values(restPrices).forEach((price) => {
+      const token = parseInt(price.instrument_token);
+      if (Number.isNaN(token)) return;
+
+      this.livePriceCache.set(token, price);
+      const callback = this.priceCallbacks.get(token);
+      if (callback) {
+        callback(price);
+      }
+    });
+
+    return restPrices;
   }
 
   /**
@@ -438,8 +862,11 @@ class ZerodhaService {
    * Get instruments list
    */
   async getInstruments(exchange = null) {
+    await this.ensureBootstrapComplete();
     if (!this.accessToken) {
-      throw new Error('Access token not provided');
+      const error = new Error('Access token not provided');
+      error.status = 400;
+      throw error;
     }
     
     try {

--- a/src/services/zerodhaServiceInstance.js
+++ b/src/services/zerodhaServiceInstance.js
@@ -1,0 +1,3 @@
+const ZerodhaService = require('./zerodhaService');
+
+module.exports = new ZerodhaService();


### PR DESCRIPTION
## Summary
- persist Zerodha API credentials, request tokens, and refresh metadata so the integration can be re-used across server restarts
- expose admin endpoints to configure Zerodha keys, trigger access-token generation, refresh tokens on demand, and inspect current status
- centralize the Zerodha service with an automatic 8:30am IST refresh scheduler that falls back to REST polling outside market hours

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden reaching https://registry.npmjs.org/node-cron)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5ed7c8e08331bbeb6d8ef34e02d7