### PR TITLE
feat: add modern trading frontend

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.dist
+.vite
+.DS_Store
+dist

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BackAPI Trader</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "backapi-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tabler/icons-react": "^2.47.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.35",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    autoprefixer: {}
+  }
+};

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,588 @@
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  color: #e2e8f0;
+  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.25), transparent 55%),
+    radial-gradient(circle at top right, rgba(236, 72, 153, 0.25), transparent 55%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.95) 0%, rgba(2, 6, 23, 0.98) 100%);
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: clamp(16px, 2.5vw, 24px) clamp(20px, 4vw, 40px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(12px);
+  background: rgba(15, 23, 42, 0.75);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(1.1rem, 1.5vw + 0.6rem, 1.6rem);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.app-header p {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.app-header__left {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.ghost-button {
+  position: relative;
+  border: none;
+  background: rgba(148, 163, 184, 0.12);
+  color: inherit;
+  padding: 10px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible {
+  background: rgba(148, 163, 184, 0.25);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.notification-dot {
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #f97316;
+  top: 10px;
+  right: 10px;
+  box-shadow: 0 0 0 6px rgba(249, 115, 22, 0.15);
+}
+
+.app-content {
+  flex: 1;
+  padding: clamp(16px, 3vw, 32px) clamp(20px, 4vw, 40px) 90px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.app-tabbar {
+  position: sticky;
+  bottom: 0;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  padding: 10px clamp(16px, 4vw, 40px) calc(env(safe-area-inset-bottom) + 10px);
+  background: rgba(15, 23, 42, 0.88);
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+  backdrop-filter: blur(12px);
+}
+
+.tabbar-item {
+  position: relative;
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: rgba(148, 163, 184, 0.7);
+  padding: 12px 10px 10px;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tabbar-item--active {
+  color: #f8fafc;
+}
+
+.tabbar-item--active svg {
+  filter: drop-shadow(0 4px 10px rgba(59, 130, 246, 0.35));
+}
+
+.tabbar-item:hover,
+.tabbar-item:focus-visible {
+  color: #f8fafc;
+  background: rgba(59, 130, 246, 0.18);
+  outline: none;
+}
+
+.tabbar-highlight {
+  position: absolute;
+  inset: auto 25% 6px;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #38bdf8 0%, #6366f1 100%);
+}
+
+@media (min-width: 960px) {
+  .app-shell {
+    border-radius: 32px;
+    margin: 24px auto;
+    max-width: 1200px;
+    box-shadow: 0 35px 120px rgba(15, 23, 42, 0.45);
+  }
+
+  .app-content {
+    padding-bottom: clamp(32px, 4vw, 56px);
+  }
+
+  .app-tabbar {
+    position: static;
+    border-radius: 24px;
+    margin: 0 clamp(24px, 4vw, 48px) clamp(24px, 3vw, 40px);
+  }
+
+  .tabbar-item {
+    flex-direction: row;
+    justify-content: center;
+    gap: 10px;
+    font-size: 0.85rem;
+    padding: 12px;
+  }
+
+  .tabbar-highlight {
+    inset: auto 20% -8px;
+  }
+}
+
+.section-card {
+  background: rgba(15, 23, 42, 0.82);
+  border-radius: 24px;
+  padding: clamp(18px, 2.5vw, 28px);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.3);
+}
+
+.section-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.section-card__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.section-card__subtitle {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.7);
+  margin-top: 6px;
+}
+
+.quick-filters {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding: 4px 2px 14px;
+  margin-bottom: 8px;
+  scrollbar-width: none;
+}
+
+.quick-filters::-webkit-scrollbar {
+  display: none;
+}
+
+.chip {
+  border: none;
+  background: rgba(148, 163, 184, 0.14);
+  color: #e2e8f0;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.chip--buy {
+  background: rgba(34, 197, 94, 0.15);
+  color: #4ade80;
+}
+
+.chip--sell {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fca5a5;
+}
+
+.chip:hover,
+.chip:focus-visible {
+  background: rgba(59, 130, 246, 0.22);
+  color: #f8fafc;
+  outline: none;
+}
+
+.watchlist-grid {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 720px) {
+  .watchlist-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.watchlist-card {
+  background: rgba(30, 41, 59, 0.65);
+  border-radius: 20px;
+  padding: 18px 20px;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  display: grid;
+  gap: 14px;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.watchlist-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(94, 234, 212, 0.3);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+}
+
+.watchlist-card header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.watchlist-card h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.watchlist-card p {
+  margin: 6px 0 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.watchlist-card__body {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.watchlist-card__body strong {
+  font-size: clamp(1.2rem, 1vw + 1rem, 1.6rem);
+  font-weight: 600;
+}
+
+.watchlist-card footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.orders-list {
+  display: grid;
+  gap: 16px;
+}
+
+.orders-card {
+  background: rgba(30, 41, 59, 0.68);
+  border-radius: 20px;
+  padding: 18px 22px;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  display: grid;
+  gap: 18px;
+}
+
+.orders-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.orders-card h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.orders-card dl {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  margin: 0;
+}
+
+.orders-card dt {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.orders-card dd {
+  margin: 4px 0 0;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.portfolio-metrics {
+  display: grid;
+  gap: 16px;
+}
+
+.portfolio-metrics article {
+  background: rgba(59, 130, 246, 0.08);
+  border-radius: 18px;
+  padding: 16px 18px;
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.06);
+}
+
+.portfolio-metrics h3 {
+  margin: 4px 0 12px;
+  font-size: 1.05rem;
+}
+
+.portfolio-holdings {
+  background: rgba(30, 41, 59, 0.68);
+  border-radius: 22px;
+  padding: 18px 22px;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  display: grid;
+  gap: 16px;
+}
+
+.portfolio-holdings header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.portfolio-holdings h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.link-button {
+  border: none;
+  background: none;
+  color: #38bdf8;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.symbol {
+  display: grid;
+  gap: 4px;
+}
+
+.symbol span {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.symbol small {
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.grid-2 {
+  display: grid;
+  gap: 18px;
+}
+
+@media (min-width: 768px) {
+  .grid-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.14);
+  color: #bae6fd;
+}
+
+.tag--success {
+  background: rgba(34, 197, 94, 0.12);
+  color: #bbf7d0;
+}
+
+.tag--warning {
+  background: rgba(249, 115, 22, 0.12);
+  color: #fed7aa;
+}
+
+.positive {
+  color: #4ade80;
+}
+
+.negative {
+  color: #f87171;
+}
+
+.muted {
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.table thead {
+  color: rgba(148, 163, 184, 0.6);
+  font-weight: 500;
+}
+
+.table th,
+.table td {
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.table tbody tr:last-of-type td {
+  border-bottom: none;
+}
+
+.progress-track {
+  width: 100%;
+  height: 6px;
+  background: rgba(148, 163, 184, 0.15);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #38bdf8 0%, #6366f1 100%);
+}
+
+.profile-grid {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 720px) {
+  .profile-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.profile-card {
+  background: rgba(30, 41, 59, 0.7);
+  border-radius: 18px;
+  padding: 16px 18px;
+  border: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.profile-card h4 {
+  margin: 0 0 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.profile-card p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.profile-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.profile-summary {
+  background: rgba(30, 41, 59, 0.75);
+  border-radius: 20px;
+  padding: 20px 22px;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.profile-summary h3 {
+  margin: 0 0 6px;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.profile-summary__cta {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.profile-summary__cta button {
+  border: none;
+  border-radius: 14px;
+  padding: 12px 16px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(90deg, #38bdf8 0%, #6366f1 100%);
+  color: #0f172a;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.profile-summary__cta button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 35px rgba(56, 189, 248, 0.3);
+}
+
+.profile-summary__cta .outline {
+  background: rgba(148, 163, 184, 0.12);
+  color: #e2e8f0;
+  box-shadow: none;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+@media (min-width: 720px) {
+  .profile-summary {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .profile-summary__cta {
+    flex-direction: row;
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,91 @@
+import { useMemo, useState } from 'react';
+import {
+  IconBell,
+  IconList,
+  IconMenu2,
+  IconStack2,
+  IconUser,
+  IconWallet,
+} from '@tabler/icons-react';
+import WatchlistTab from './components/WatchlistTab.jsx';
+import OrdersTab from './components/OrdersTab.jsx';
+import PortfolioTab from './components/PortfolioTab.jsx';
+import ProfileTab from './components/ProfileTab.jsx';
+import './App.css';
+
+const tabs = [
+  {
+    key: 'watchlist',
+    label: 'Watchlist',
+    icon: IconList,
+  },
+  {
+    key: 'orders',
+    label: 'Orders',
+    icon: IconStack2,
+  },
+  {
+    key: 'portfolio',
+    label: 'Portfolio',
+    icon: IconWallet,
+  },
+  {
+    key: 'profile',
+    label: 'Profile',
+    icon: IconUser,
+  },
+];
+
+const tabComponents = {
+  watchlist: WatchlistTab,
+  orders: OrdersTab,
+  portfolio: PortfolioTab,
+  profile: ProfileTab,
+};
+
+export default function App() {
+  const [activeTab, setActiveTab] = useState('watchlist');
+  const TabComponent = useMemo(() => tabComponents[activeTab], [activeTab]);
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <div className="app-header__left">
+          <button className="ghost-button" aria-label="Menu">
+            <IconMenu2 size={22} />
+          </button>
+          <div>
+            <h1>BackAPI Trader</h1>
+            <p>Smart investing, inspired by Zerodha &amp; Upstox</p>
+          </div>
+        </div>
+        <button className="ghost-button" aria-label="Notifications">
+          <IconBell size={22} />
+          <span className="notification-dot" aria-hidden="true" />
+        </button>
+      </header>
+
+      <main className="app-content">
+        <TabComponent />
+      </main>
+
+      <nav className="app-tabbar" aria-label="Main navigation">
+        {tabs.map(({ key, label, icon: Icon }) => {
+          const isActive = key === activeTab;
+          return (
+            <button
+              key={key}
+              type="button"
+              className={`tabbar-item ${isActive ? 'tabbar-item--active' : ''}`}
+              onClick={() => setActiveTab(key)}
+            >
+              <Icon size={22} strokeWidth={isActive ? 2.2 : 1.8} />
+              <span>{label}</span>
+              {isActive && <span className="tabbar-highlight" aria-hidden="true" />}
+            </button>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/frontend/src/components/OrdersTab.jsx
+++ b/frontend/src/components/OrdersTab.jsx
@@ -1,0 +1,87 @@
+import { IconClockHour4, IconDownload } from '@tabler/icons-react';
+
+const orders = [
+  {
+    id: 'ORD-98231',
+    symbol: 'INFY',
+    type: 'Buy',
+    qty: 40,
+    price: '1,455.20',
+    status: 'Executed',
+    time: '09:17 AM',
+  },
+  {
+    id: 'ORD-98221',
+    symbol: 'RELIANCE',
+    type: 'Sell',
+    qty: 10,
+    price: '2,398.00',
+    status: 'Pending',
+    time: '09:12 AM',
+  },
+  {
+    id: 'ORD-98192',
+    symbol: 'NIFTY23APR22600CE',
+    type: 'Buy',
+    qty: 75,
+    price: '132.40',
+    status: 'Partially Filled',
+    time: '09:04 AM',
+  },
+];
+
+export default function OrdersTab() {
+  return (
+    <div className="section-card">
+      <div className="section-card__header">
+        <div>
+          <div className="tag tag--warning">
+            <IconClockHour4 size={14} />
+            Today
+          </div>
+          <h2 className="section-card__title">Order flow</h2>
+          <p className="section-card__subtitle">
+            Monitor filled, pending and rejected orders in real time.
+          </p>
+        </div>
+        <button type="button" className="ghost-button" aria-label="Download report">
+          <IconDownload size={18} />
+        </button>
+      </div>
+
+      <div className="orders-list">
+        {orders.map((order) => (
+          <article key={order.id} className="orders-card">
+            <header>
+              <div>
+                <h3>{order.symbol}</h3>
+                <p className="muted">{order.id}</p>
+              </div>
+              <span className={`chip chip--${order.type === 'Buy' ? 'buy' : 'sell'}`}>
+                {order.type}
+              </span>
+            </header>
+            <dl>
+              <div>
+                <dt>Quantity</dt>
+                <dd>{order.qty}</dd>
+              </div>
+              <div>
+                <dt>Price</dt>
+                <dd>{order.price}</dd>
+              </div>
+              <div>
+                <dt>Status</dt>
+                <dd>{order.status}</dd>
+              </div>
+              <div>
+                <dt>Time</dt>
+                <dd>{order.time}</dd>
+              </div>
+            </dl>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PortfolioTab.jsx
+++ b/frontend/src/components/PortfolioTab.jsx
@@ -1,0 +1,107 @@
+import { IconArrowUpRight, IconChevronRight, IconMoodSmile } from '@tabler/icons-react';
+
+const holdings = [
+  {
+    symbol: 'TCS',
+    name: 'Tata Consultancy',
+    qty: 20,
+    avg: '3,210.00',
+    ltp: '3,462.10',
+    pnl: '+5.82%',
+  },
+  {
+    symbol: 'BAJFINANCE',
+    name: 'Bajaj Finance',
+    qty: 6,
+    avg: '6,720.00',
+    ltp: '7,180.50',
+    pnl: '+6.85%',
+  },
+  {
+    symbol: 'ITC',
+    name: 'ITC Limited',
+    qty: 80,
+    avg: '402.20',
+    ltp: '414.80',
+    pnl: '+3.11%',
+  },
+];
+
+const metrics = [
+  { label: 'Overall returns', value: '+₹ 46,820', trend: 'positive' },
+  { label: 'Invested value', value: '₹ 7,80,000', trend: 'muted' },
+  { label: 'Day change', value: '+₹ 4,280 (0.84%)', trend: 'positive' },
+  { label: 'Available margin', value: '₹ 1,50,000', trend: 'muted' },
+];
+
+export default function PortfolioTab() {
+  return (
+    <div className="section-card">
+      <div className="section-card__header">
+        <div>
+          <div className="tag tag--success">
+            <IconMoodSmile size={14} />
+            Healthy
+          </div>
+          <h2 className="section-card__title">Portfolio pulse</h2>
+          <p className="section-card__subtitle">
+            Diversify confidently with actionable insights.
+          </p>
+        </div>
+        <button type="button" className="ghost-button" aria-label="Rebalance">
+          <IconArrowUpRight size={18} />
+        </button>
+      </div>
+
+      <div className="grid-2">
+        <section className="portfolio-metrics">
+          {metrics.map((metric) => (
+            <article key={metric.label}>
+              <p className="muted">{metric.label}</p>
+              <h3 className={metric.trend}>{metric.value}</h3>
+              <div className="progress-track" aria-hidden="true">
+                <div className="progress-fill" style={{ width: metric.trend === 'positive' ? '82%' : '46%' }} />
+              </div>
+            </article>
+          ))}
+        </section>
+        <section className="portfolio-holdings">
+          <header>
+            <h3>Top holdings</h3>
+            <button type="button" className="link-button">
+              View all
+              <IconChevronRight size={16} strokeWidth={1.8} />
+            </button>
+          </header>
+          <table className="table" role="grid">
+            <thead>
+              <tr>
+                <th align="left">Symbol</th>
+                <th align="left">Qty</th>
+                <th align="left">Avg</th>
+                <th align="left">LTP</th>
+                <th align="left">P&amp;L</th>
+              </tr>
+            </thead>
+            <tbody>
+              {holdings.map((holding) => (
+                <tr key={holding.symbol}>
+                  <td>
+                    <div className="symbol">
+                      <span>{holding.symbol}</span>
+                      <small>{holding.name}</small>
+                    </div>
+                  </td>
+                  <td>{holding.qty}</td>
+                  <td>{holding.avg}</td>
+                  <td>{holding.ltp}</td>
+                  <td className="positive">{holding.pnl}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ProfileTab.jsx
+++ b/frontend/src/components/ProfileTab.jsx
@@ -1,0 +1,76 @@
+import { IconDeviceMobile, IconLogout, IconSettings, IconShieldLock } from '@tabler/icons-react';
+
+const profileDetails = [
+  {
+    title: 'Account tier',
+    value: 'Prime Investor',
+    description: 'Enjoy priority support, zero AMC and enhanced charting.',
+  },
+  {
+    title: 'Linked accounts',
+    value: '4 broker connections',
+    description: 'Zerodha, Upstox, Angel One and Groww synced in real-time.',
+  },
+  {
+    title: '2FA status',
+    value: 'Secure with Authenticator',
+    description: 'Biometric fallback active, device trusted for 30 days.',
+  },
+  {
+    title: 'API usage',
+    value: '12,480 calls today',
+    description: 'Automations and webhooks are running efficiently.',
+  },
+];
+
+export default function ProfileTab() {
+  return (
+    <div className="section-card">
+      <div className="section-card__header">
+        <div>
+          <div className="tag">
+            <IconShieldLock size={14} />
+            Secure
+          </div>
+          <h2 className="section-card__title">Profile &amp; preferences</h2>
+          <p className="section-card__subtitle">
+            Manage accounts, devices and API keys across brokers.
+          </p>
+        </div>
+        <div className="profile-actions">
+          <button type="button" className="ghost-button" aria-label="Security settings">
+            <IconSettings size={18} />
+          </button>
+          <button type="button" className="ghost-button" aria-label="Logout">
+            <IconLogout size={18} />
+          </button>
+        </div>
+      </div>
+
+      <div className="profile-summary">
+        <article>
+          <h3>Ananya Sharma</h3>
+          <p className="muted">Client ID: BA12345</p>
+          <div className="tag tag--success">
+            <IconDeviceMobile size={14} />
+            Mobile verified
+          </div>
+        </article>
+        <div className="profile-summary__cta">
+          <button type="button">Switch to paper trading</button>
+          <button type="button" className="outline">Generate API token</button>
+        </div>
+      </div>
+
+      <div className="profile-grid">
+        {profileDetails.map((detail) => (
+          <article key={detail.title} className="profile-card">
+            <h4>{detail.title}</h4>
+            <p>{detail.value}</p>
+            <p>{detail.description}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/WatchlistTab.jsx
+++ b/frontend/src/components/WatchlistTab.jsx
@@ -1,0 +1,92 @@
+import { IconChevronRight, IconPlus, IconTrendingUp } from '@tabler/icons-react';
+
+const watchlistItems = [
+  {
+    symbol: 'NIFTY 50',
+    name: 'NSE Index',
+    price: '22,200.60',
+    change: '+0.84%',
+    direction: 'up',
+    volume: '1.2M',
+  },
+  {
+    symbol: 'RELIANCE',
+    name: 'Reliance Industries',
+    price: '2,398.35',
+    change: '-0.42%',
+    direction: 'down',
+    volume: '845K',
+  },
+  {
+    symbol: 'TCS',
+    name: 'Tata Consultancy',
+    price: '3,462.10',
+    change: '+1.26%',
+    direction: 'up',
+    volume: '412K',
+  },
+  {
+    symbol: 'HDFCBANK',
+    name: 'HDFC Bank',
+    price: '1,501.85',
+    change: '+0.32%',
+    direction: 'up',
+    volume: '615K',
+  },
+];
+
+const quickFilters = ['All', 'NSE', 'BSE', 'F&O', 'Crypto'];
+
+export default function WatchlistTab() {
+  return (
+    <div className="section-card">
+      <div className="section-card__header">
+        <div>
+          <div className="tag">
+            <IconTrendingUp size={14} />
+            Live Markets
+          </div>
+          <h2 className="section-card__title">Your smart watchlists</h2>
+          <p className="section-card__subtitle">
+            Track indices, stocks &amp; derivatives with lightning-fast updates.
+          </p>
+        </div>
+        <button type="button" className="ghost-button" aria-label="Create watchlist">
+          <IconPlus size={18} />
+        </button>
+      </div>
+
+      <div className="quick-filters">
+        {quickFilters.map((filter) => (
+          <button key={filter} type="button" className="chip">
+            {filter}
+          </button>
+        ))}
+      </div>
+
+      <div className="watchlist-grid">
+        {watchlistItems.map((item) => (
+          <article key={item.symbol} className="watchlist-card">
+            <header>
+              <div>
+                <h3>{item.symbol}</h3>
+                <p>{item.name}</p>
+              </div>
+              <IconChevronRight size={18} strokeWidth={1.8} />
+            </header>
+            <div className="watchlist-card__body">
+              <strong>{item.price}</strong>
+              <span className={item.direction === 'up' ? 'positive' : 'negative'}>
+                {item.change}
+              </span>
+            </div>
+            <footer>
+              <span className="muted">Volume</span>
+              <span>{item.volume}</span>
+            </footer>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,26 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0f172a;
+  color: #0f172a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  background: linear-gradient(180deg, #0f172a 0%, #020617 100%);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+#root {
+  min-height: 100vh;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- add a Vite-powered React frontend scaffold targeting a multi-tab trading experience
- implement watchlist, orders, portfolio, and profile views with responsive styling inspired by leading brokers

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e14fbdd53c8331a7899048ba21863b