### PR TITLE
refine watchlist live feed handling

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.dist
+.vite
+.DS_Store
+dist

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BackAPI Trader</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "backapi-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tabler/icons-react": "^2.47.0",
+    "fuse.js": "^6.6.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.35",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    autoprefixer: {}
+  }
+};

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,979 @@
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  color: #e2e8f0;
+  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.25), transparent 55%),
+    radial-gradient(circle at top right, rgba(236, 72, 153, 0.25), transparent 55%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.95) 0%, rgba(2, 6, 23, 0.98) 100%);
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: clamp(16px, 2.5vw, 24px) clamp(20px, 4vw, 40px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(12px);
+  background: rgba(15, 23, 42, 0.75);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(1.1rem, 1.5vw + 0.6rem, 1.6rem);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.app-header p {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.app-header__left {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.ghost-button {
+  position: relative;
+  border: none;
+  background: rgba(148, 163, 184, 0.12);
+  color: inherit;
+  padding: 10px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible {
+  background: rgba(148, 163, 184, 0.25);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.notification-dot {
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #f97316;
+  top: 10px;
+  right: 10px;
+  box-shadow: 0 0 0 6px rgba(249, 115, 22, 0.15);
+}
+
+.app-content {
+  flex: 1;
+  padding: clamp(16px, 3vw, 32px) clamp(20px, 4vw, 40px) 90px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.app-tabbar {
+  position: sticky;
+  bottom: 0;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  padding: 10px clamp(16px, 4vw, 40px) calc(env(safe-area-inset-bottom) + 10px);
+  background: rgba(15, 23, 42, 0.88);
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+  backdrop-filter: blur(12px);
+}
+
+.tabbar-item {
+  position: relative;
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: rgba(148, 163, 184, 0.7);
+  padding: 12px 10px 10px;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tabbar-item--active {
+  color: #f8fafc;
+}
+
+.tabbar-item--active svg {
+  filter: drop-shadow(0 4px 10px rgba(59, 130, 246, 0.35));
+}
+
+.tabbar-item:hover,
+.tabbar-item:focus-visible {
+  color: #f8fafc;
+  background: rgba(59, 130, 246, 0.18);
+  outline: none;
+}
+
+.tabbar-highlight {
+  position: absolute;
+  inset: auto 25% 6px;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #38bdf8 0%, #6366f1 100%);
+}
+
+@media (min-width: 960px) {
+  .app-shell {
+    border-radius: 32px;
+    margin: 24px auto;
+    max-width: 1200px;
+    box-shadow: 0 35px 120px rgba(15, 23, 42, 0.45);
+  }
+
+  .app-content {
+    padding-bottom: clamp(32px, 4vw, 56px);
+  }
+
+  .app-tabbar {
+    position: static;
+    border-radius: 24px;
+    margin: 0 clamp(24px, 4vw, 48px) clamp(24px, 3vw, 40px);
+  }
+
+  .tabbar-item {
+    flex-direction: row;
+    justify-content: center;
+    gap: 10px;
+    font-size: 0.85rem;
+    padding: 12px;
+  }
+
+  .tabbar-highlight {
+    inset: auto 20% -8px;
+  }
+}
+
+.section-card {
+  background: rgba(15, 23, 42, 0.82);
+  border-radius: 24px;
+  padding: clamp(18px, 2.5vw, 28px);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.3);
+}
+
+.section-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.section-card__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.section-card__subtitle {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.7);
+  margin-top: 6px;
+}
+
+.quick-filters {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding: 4px 2px 14px;
+  margin-bottom: 8px;
+  scrollbar-width: none;
+}
+
+.quick-filters::-webkit-scrollbar {
+  display: none;
+}
+
+.chip {
+  border: none;
+  background: rgba(148, 163, 184, 0.14);
+  color: #e2e8f0;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.chip--buy {
+  background: rgba(34, 197, 94, 0.15);
+  color: #4ade80;
+}
+
+.chip--sell {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fca5a5;
+}
+
+.chip:hover,
+.chip:focus-visible {
+  background: rgba(59, 130, 246, 0.22);
+  color: #f8fafc;
+  outline: none;
+}
+
+.chip--active {
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.32) 0%, rgba(14, 165, 233, 0.28) 100%);
+  color: #f8fafc;
+  border: 1px solid rgba(96, 165, 250, 0.55);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+}
+
+.chip--active:hover,
+.chip--active:focus-visible {
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.42) 0%, rgba(14, 165, 233, 0.38) 100%);
+}
+
+.chip--primary {
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.2) 0%, rgba(129, 140, 248, 0.35) 100%);
+  color: #e0f2fe;
+  border: 1px solid rgba(125, 211, 252, 0.45);
+  box-shadow: 0 12px 24px rgba(14, 116, 144, 0.25);
+}
+
+.chip--primary:hover,
+.chip--primary:focus-visible {
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.3) 0%, rgba(129, 140, 248, 0.45) 100%);
+  color: #f8fafc;
+  border-color: rgba(125, 211, 252, 0.65);
+}
+
+.watchlist-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.watchlist-search {
+  position: relative;
+  flex: 1;
+  min-width: 220px;
+  display: flex;
+  align-items: center;
+}
+
+.watchlist-search svg {
+  position: absolute;
+  left: 16px;
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.watchlist-search input {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+  padding: 10px 16px 10px 42px;
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.watchlist-search input::placeholder {
+  color: rgba(148, 163, 184, 0.55);
+}
+
+.watchlist-search input:focus-visible {
+  outline: none;
+  border-color: rgba(129, 140, 248, 0.6);
+  background: rgba(30, 41, 59, 0.85);
+  box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.25);
+}
+
+.live-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  background: rgba(34, 197, 94, 0.12);
+  color: #4ade80;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+}
+
+.live-indicator svg {
+  color: currentColor;
+}
+
+.live-indicator--error {
+  background: rgba(248, 113, 113, 0.12);
+  color: #f87171;
+  border-color: rgba(248, 113, 113, 0.35);
+}
+
+.live-indicator--pending {
+  background: rgba(59, 130, 246, 0.14);
+  color: #93c5fd;
+  border-color: rgba(96, 165, 250, 0.35);
+}
+
+.live-indicator--degraded {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+  border-color: rgba(251, 191, 36, 0.28);
+}
+
+.live-indicator--idle {
+  background: rgba(148, 163, 184, 0.16);
+  color: #cbd5f5;
+  border-color: rgba(148, 163, 184, 0.28);
+}
+
+.live-indicator--active {
+  animation: pulseGlow 2.6s ease-in-out infinite;
+}
+
+@keyframes pulseGlow {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.2);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(34, 197, 94, 0);
+  }
+}
+
+.alert {
+  margin-top: 16px;
+  padding: 14px 18px;
+  border-radius: 18px;
+  border: 1px solid transparent;
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  background: rgba(30, 41, 59, 0.85);
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.alert svg {
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.alert p {
+  margin: 2px 0 0;
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.alert--error {
+  border-color: rgba(248, 113, 113, 0.35);
+  background: rgba(248, 113, 113, 0.1);
+  color: #fecaca;
+}
+
+.alert--error p {
+  color: rgba(254, 226, 226, 0.75);
+}
+
+.watchlist-empty {
+  margin-top: 24px;
+  padding: 36px 24px;
+  border-radius: 24px;
+  text-align: center;
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.8) 0%, rgba(30, 41, 59, 0.88) 100%);
+  color: rgba(226, 232, 240, 0.72);
+  display: grid;
+  gap: 8px;
+  justify-items: center;
+}
+
+.watchlist-empty strong {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #f1f5f9;
+}
+
+.watchlist-grid {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 720px) {
+  .watchlist-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.watchlist-card {
+  background: rgba(30, 41, 59, 0.65);
+  border-radius: 20px;
+  padding: 18px 20px;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  display: grid;
+  gap: 14px;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.watchlist-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(94, 234, 212, 0.3);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+}
+
+.watchlist-card header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.watchlist-card h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.watchlist-card p {
+  margin: 6px 0 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.watchlist-card__body {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.watchlist-card__body strong {
+  font-size: clamp(1.2rem, 1vw + 1rem, 1.6rem);
+  font-weight: 600;
+}
+
+.watchlist-card footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.orders-list {
+  display: grid;
+  gap: 16px;
+}
+
+.orders-card {
+  background: rgba(30, 41, 59, 0.68);
+  border-radius: 20px;
+  padding: 18px 22px;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  display: grid;
+  gap: 18px;
+}
+
+.orders-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.orders-card h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.orders-card dl {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  margin: 0;
+}
+
+.orders-card dt {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.orders-card dd {
+  margin: 4px 0 0;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.portfolio-metrics {
+  display: grid;
+  gap: 16px;
+}
+
+.portfolio-metrics article {
+  background: rgba(59, 130, 246, 0.08);
+  border-radius: 18px;
+  padding: 16px 18px;
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.06);
+}
+
+.portfolio-metrics h3 {
+  margin: 4px 0 12px;
+  font-size: 1.05rem;
+}
+
+.portfolio-holdings {
+  background: rgba(30, 41, 59, 0.68);
+  border-radius: 22px;
+  padding: 18px 22px;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  display: grid;
+  gap: 16px;
+}
+
+.portfolio-holdings header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.portfolio-holdings h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.link-button {
+  border: none;
+  background: none;
+  color: #38bdf8;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.symbol {
+  display: grid;
+  gap: 4px;
+}
+
+.symbol span {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.symbol small {
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.grid-2 {
+  display: grid;
+  gap: 18px;
+}
+
+@media (min-width: 768px) {
+  .grid-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.14);
+  color: #bae6fd;
+}
+
+.tag--success {
+  background: rgba(34, 197, 94, 0.12);
+  color: #bbf7d0;
+}
+
+.tag--warning {
+  background: rgba(249, 115, 22, 0.12);
+  color: #fed7aa;
+}
+
+.positive {
+  color: #4ade80;
+}
+
+.negative {
+  color: #f87171;
+}
+
+.muted {
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.table thead {
+  color: rgba(148, 163, 184, 0.6);
+  font-weight: 500;
+}
+
+.table th,
+.table td {
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.table tbody tr:last-of-type td {
+  border-bottom: none;
+}
+
+.progress-track {
+  width: 100%;
+  height: 6px;
+  background: rgba(148, 163, 184, 0.15);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #38bdf8 0%, #6366f1 100%);
+}
+
+.profile-grid {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 720px) {
+  .profile-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.profile-card {
+  background: rgba(30, 41, 59, 0.7);
+  border-radius: 18px;
+  padding: 16px 18px;
+  border: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.profile-card h4 {
+  margin: 0 0 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.profile-card p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.profile-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.profile-summary {
+  background: rgba(30, 41, 59, 0.75);
+  border-radius: 20px;
+  padding: 20px 22px;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.profile-summary h3 {
+  margin: 0 0 6px;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.profile-summary__cta {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.profile-summary__cta button {
+  border: none;
+  border-radius: 14px;
+  padding: 12px 16px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(90deg, #38bdf8 0%, #6366f1 100%);
+  color: #0f172a;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.profile-summary__cta button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 35px rgba(56, 189, 248, 0.3);
+}
+
+.profile-summary__cta .outline {
+  background: rgba(148, 163, 184, 0.12);
+  color: #e2e8f0;
+  box-shadow: none;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+@media (min-width: 720px) {
+  .profile-summary {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .profile-summary__cta {
+    flex-direction: row;
+  }
+}
+
+.tag--brand {
+  background: rgba(14, 165, 233, 0.18);
+  color: #bae6fd;
+  border: 1px solid rgba(125, 211, 252, 0.4);
+}
+
+.admin-dashboard {
+  display: grid;
+  gap: 22px;
+}
+
+.admin-dashboard__hero {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.admin-dashboard__hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.admin-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.admin-card {
+  display: grid;
+  gap: 18px;
+}
+
+.admin-card header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.admin-card header h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.admin-card header .ghost-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  font-size: 0.75rem;
+  border-radius: 14px;
+}
+
+.admin-card__footer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.85);
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.admin-card--wide {
+  grid-column: 1 / -1;
+}
+
+.admin-card--activity {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.admin-card--activity header h3 {
+  font-size: 1rem;
+}
+
+.table__head,
+.table__row {
+  display: grid;
+  grid-template-columns: 1.2fr 2fr 1fr 1fr 1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 0;
+}
+
+.table__head {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.6);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.table__row {
+  font-size: 0.85rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.table__row:last-of-type {
+  border-bottom: none;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.pill--success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #4ade80;
+}
+
+.token-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+}
+
+.token-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.token-list li:last-of-type {
+  border-bottom: none;
+}
+
+.token-list strong {
+  font-size: 0.9rem;
+}
+
+.token-list code {
+  display: inline-flex;
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 10px;
+  padding: 6px 10px;
+  font-size: 0.75rem;
+  color: #bae6fd;
+}
+
+.stat-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.stat-grid div {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 16px;
+  padding: 12px 14px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  display: grid;
+  gap: 4px;
+}
+
+.audit-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+}
+
+.audit-list li {
+  display: grid;
+  gap: 6px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.audit-list li:last-of-type {
+  border-bottom: none;
+}
+
+.audit-list strong {
+  font-size: 0.9rem;
+}
+
+@media (min-width: 960px) {
+  .admin-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .admin-card--wide {
+    grid-column: 1 / -1;
+  }
+
+  .admin-card--activity {
+    grid-column: 1 / -1;
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,99 @@
+import { useMemo, useState } from 'react';
+import {
+  IconBell,
+  IconBuildingSkyscraper,
+  IconList,
+  IconMenu2,
+  IconStack2,
+  IconUser,
+  IconWallet,
+} from '@tabler/icons-react';
+import WatchlistTab from './components/WatchlistTab.jsx';
+import OrdersTab from './components/OrdersTab.jsx';
+import PortfolioTab from './components/PortfolioTab.jsx';
+import ProfileTab from './components/ProfileTab.jsx';
+import AdminDashboard from './components/AdminDashboard.jsx';
+import './App.css';
+
+const tabs = [
+  {
+    key: 'watchlist',
+    label: 'Watchlist',
+    icon: IconList,
+  },
+  {
+    key: 'orders',
+    label: 'Orders',
+    icon: IconStack2,
+  },
+  {
+    key: 'portfolio',
+    label: 'Portfolio',
+    icon: IconWallet,
+  },
+  {
+    key: 'profile',
+    label: 'Profile',
+    icon: IconUser,
+  },
+  {
+    key: 'admin',
+    label: 'Admin',
+    icon: IconBuildingSkyscraper,
+  },
+];
+
+const tabComponents = {
+  watchlist: WatchlistTab,
+  orders: OrdersTab,
+  portfolio: PortfolioTab,
+  profile: ProfileTab,
+  admin: AdminDashboard,
+};
+
+export default function App() {
+  const [activeTab, setActiveTab] = useState('watchlist');
+  const TabComponent = useMemo(() => tabComponents[activeTab], [activeTab]);
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <div className="app-header__left">
+          <button className="ghost-button" aria-label="Menu">
+            <IconMenu2 size={22} />
+          </button>
+          <div>
+            <h1>BackAPI Trader</h1>
+            <p>Smart investing, inspired by Zerodha &amp; Upstox</p>
+          </div>
+        </div>
+        <button className="ghost-button" aria-label="Notifications">
+          <IconBell size={22} />
+          <span className="notification-dot" aria-hidden="true" />
+        </button>
+      </header>
+
+      <main className="app-content">
+        <TabComponent />
+      </main>
+
+      <nav className="app-tabbar" aria-label="Main navigation">
+        {tabs.map(({ key, label, icon: Icon }) => {
+          const isActive = key === activeTab;
+          return (
+            <button
+              key={key}
+              type="button"
+              className={`tabbar-item ${isActive ? 'tabbar-item--active' : ''}`}
+              onClick={() => setActiveTab(key)}
+            >
+              <Icon size={22} strokeWidth={isActive ? 2.2 : 1.8} />
+              <span>{label}</span>
+              {isActive && <span className="tabbar-highlight" aria-hidden="true" />}
+            </button>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/frontend/src/components/AdminDashboard.jsx
+++ b/frontend/src/components/AdminDashboard.jsx
@@ -1,0 +1,209 @@
+import {
+  IconAdjustments,
+  IconApi,
+  IconChecklist,
+  IconDeviceFloppy,
+  IconLayoutGrid,
+  IconPlus,
+  IconRefresh,
+  IconShieldLock,
+  IconUpload,
+  IconUsersGroup,
+} from '@tabler/icons-react';
+
+const instrumentRows = [
+  {
+    symbol: 'RELIANCE',
+    name: 'Reliance Industries',
+    exchange: 'NSE',
+    segment: 'EQ',
+    status: 'Active',
+  },
+  {
+    symbol: 'TCS',
+    name: 'Tata Consultancy Services',
+    exchange: 'NSE',
+    segment: 'EQ',
+    status: 'Active',
+  },
+  {
+    symbol: 'NIFTY 50',
+    name: 'Nifty Index',
+    exchange: 'NSE',
+    segment: 'Index',
+    status: 'Tracked',
+  },
+];
+
+const tokens = [
+  { label: 'Primary Trading Token', value: 'kite_live_x1h8...', scope: 'Trading APIs', expires: '3 hrs' },
+  { label: 'Historical Data Token', value: 'historical_e9k2...', scope: 'Data APIs', expires: '12 hrs' },
+];
+
+const auditEvents = [
+  { actor: 'Admin', action: 'Updated margin requirements', time: '2 mins ago' },
+  { actor: 'Deal Desk', action: 'Approved access token refresh', time: '14 mins ago' },
+  { actor: 'Ops Bot', action: 'Synced 152 new NSE instruments', time: '38 mins ago' },
+];
+
+export default function AdminDashboard() {
+  return (
+    <div className="admin-dashboard">
+      <header className="section-card admin-dashboard__hero">
+        <div>
+          <div className="tag tag--brand">
+            <IconShieldLock size={14} />
+            Admin Control Centre
+          </div>
+          <h2 className="section-card__title">Operational oversight in one place</h2>
+          <p className="section-card__subtitle">
+            Manage market instruments, API credentials, user access, and system automations with
+            enterprise-grade safety.
+          </p>
+        </div>
+        <div className="admin-dashboard__hero-actions">
+          <button type="button" className="chip chip--primary">
+            <IconPlus size={16} />
+            New Instrument
+          </button>
+          <button type="button" className="chip">
+            <IconRefresh size={16} />
+            Sync with Exchange
+          </button>
+        </div>
+      </header>
+
+      <section className="admin-grid">
+        <article className="section-card admin-card admin-card--wide" aria-label="Instrument catalogue">
+          <header>
+            <div>
+              <h3>
+                <IconLayoutGrid size={18} /> Instruments catalogue
+              </h3>
+              <p className="section-card__subtitle">
+                Curate tradable symbols and instantly publish changes to the trading experience.
+              </p>
+            </div>
+            <button type="button" className="ghost-button">
+              <IconUpload size={18} />
+              Bulk import CSV
+            </button>
+          </header>
+
+          <div className="table">
+            <div className="table__head">
+              <span>Symbol</span>
+              <span>Name</span>
+              <span>Exchange</span>
+              <span>Segment</span>
+              <span>Status</span>
+            </div>
+            {instrumentRows.map((row) => (
+              <div key={row.symbol} className="table__row">
+                <span>{row.symbol}</span>
+                <span>{row.name}</span>
+                <span>{row.exchange}</span>
+                <span>{row.segment}</span>
+                <span>
+                  <span className="pill pill--success">{row.status}</span>
+                </span>
+              </div>
+            ))}
+          </div>
+        </article>
+
+        <article className="section-card admin-card" aria-label="Access tokens">
+          <header>
+            <div>
+              <h3>
+                <IconApi size={18} /> Zerodha access tokens
+              </h3>
+              <p className="section-card__subtitle">
+                Rotate secrets and monitor expiry across live and sandbox environments.
+              </p>
+            </div>
+            <button type="button" className="ghost-button">
+              <IconDeviceFloppy size={18} />
+              Generate new token
+            </button>
+          </header>
+
+          <ul className="token-list">
+            {tokens.map((token) => (
+              <li key={token.value}>
+                <div>
+                  <strong>{token.label}</strong>
+                  <p>{token.scope}</p>
+                </div>
+                <div>
+                  <code>{token.value}</code>
+                  <span className="muted">Expires in {token.expires}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </article>
+
+        <article className="section-card admin-card" aria-label="User administration">
+          <header>
+            <div>
+              <h3>
+                <IconUsersGroup size={18} /> Active users
+              </h3>
+              <p className="section-card__subtitle">
+                Review permissions, last login, and compliance checklists instantly.
+              </p>
+            </div>
+            <button type="button" className="ghost-button">
+              <IconAdjustments size={18} />
+              Manage roles
+            </button>
+          </header>
+
+          <div className="stat-grid">
+            <div>
+              <span className="muted">Total users</span>
+              <strong>248</strong>
+            </div>
+            <div>
+              <span className="muted">Pending KYC</span>
+              <strong className="negative">6</strong>
+            </div>
+            <div>
+              <span className="muted">2FA Enabled</span>
+              <strong className="positive">96%</strong>
+            </div>
+          </div>
+
+          <footer className="admin-card__footer">
+            <IconChecklist size={18} />
+            <span>Automations run every 15 minutes to reconcile user entitlements.</span>
+          </footer>
+        </article>
+
+        <article className="section-card admin-card admin-card--activity" aria-label="Audit trail">
+          <header>
+            <div>
+              <h3>Latest automation &amp; audit log</h3>
+              <p className="section-card__subtitle">
+                Every change to risk, tokens, and instruments is captured for compliance.
+              </p>
+            </div>
+          </header>
+
+          <ul className="audit-list">
+            {auditEvents.map((event) => (
+              <li key={`${event.actor}-${event.time}`}>
+                <div>
+                  <strong>{event.actor}</strong>
+                  <span className="muted">{event.time}</span>
+                </div>
+                <p>{event.action}</p>
+              </li>
+            ))}
+          </ul>
+        </article>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/OrdersTab.jsx
+++ b/frontend/src/components/OrdersTab.jsx
@@ -1,0 +1,87 @@
+import { IconClockHour4, IconDownload } from '@tabler/icons-react';
+
+const orders = [
+  {
+    id: 'ORD-98231',
+    symbol: 'INFY',
+    type: 'Buy',
+    qty: 40,
+    price: '1,455.20',
+    status: 'Executed',
+    time: '09:17 AM',
+  },
+  {
+    id: 'ORD-98221',
+    symbol: 'RELIANCE',
+    type: 'Sell',
+    qty: 10,
+    price: '2,398.00',
+    status: 'Pending',
+    time: '09:12 AM',
+  },
+  {
+    id: 'ORD-98192',
+    symbol: 'NIFTY23APR22600CE',
+    type: 'Buy',
+    qty: 75,
+    price: '132.40',
+    status: 'Partially Filled',
+    time: '09:04 AM',
+  },
+];
+
+export default function OrdersTab() {
+  return (
+    <div className="section-card">
+      <div className="section-card__header">
+        <div>
+          <div className="tag tag--warning">
+            <IconClockHour4 size={14} />
+            Today
+          </div>
+          <h2 className="section-card__title">Order flow</h2>
+          <p className="section-card__subtitle">
+            Monitor filled, pending and rejected orders in real time.
+          </p>
+        </div>
+        <button type="button" className="ghost-button" aria-label="Download report">
+          <IconDownload size={18} />
+        </button>
+      </div>
+
+      <div className="orders-list">
+        {orders.map((order) => (
+          <article key={order.id} className="orders-card">
+            <header>
+              <div>
+                <h3>{order.symbol}</h3>
+                <p className="muted">{order.id}</p>
+              </div>
+              <span className={`chip chip--${order.type === 'Buy' ? 'buy' : 'sell'}`}>
+                {order.type}
+              </span>
+            </header>
+            <dl>
+              <div>
+                <dt>Quantity</dt>
+                <dd>{order.qty}</dd>
+              </div>
+              <div>
+                <dt>Price</dt>
+                <dd>{order.price}</dd>
+              </div>
+              <div>
+                <dt>Status</dt>
+                <dd>{order.status}</dd>
+              </div>
+              <div>
+                <dt>Time</dt>
+                <dd>{order.time}</dd>
+              </div>
+            </dl>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PortfolioTab.jsx
+++ b/frontend/src/components/PortfolioTab.jsx
@@ -1,0 +1,107 @@
+import { IconArrowUpRight, IconChevronRight, IconMoodSmile } from '@tabler/icons-react';
+
+const holdings = [
+  {
+    symbol: 'TCS',
+    name: 'Tata Consultancy',
+    qty: 20,
+    avg: '3,210.00',
+    ltp: '3,462.10',
+    pnl: '+5.82%',
+  },
+  {
+    symbol: 'BAJFINANCE',
+    name: 'Bajaj Finance',
+    qty: 6,
+    avg: '6,720.00',
+    ltp: '7,180.50',
+    pnl: '+6.85%',
+  },
+  {
+    symbol: 'ITC',
+    name: 'ITC Limited',
+    qty: 80,
+    avg: '402.20',
+    ltp: '414.80',
+    pnl: '+3.11%',
+  },
+];
+
+const metrics = [
+  { label: 'Overall returns', value: '+₹ 46,820', trend: 'positive' },
+  { label: 'Invested value', value: '₹ 7,80,000', trend: 'muted' },
+  { label: 'Day change', value: '+₹ 4,280 (0.84%)', trend: 'positive' },
+  { label: 'Available margin', value: '₹ 1,50,000', trend: 'muted' },
+];
+
+export default function PortfolioTab() {
+  return (
+    <div className="section-card">
+      <div className="section-card__header">
+        <div>
+          <div className="tag tag--success">
+            <IconMoodSmile size={14} />
+            Healthy
+          </div>
+          <h2 className="section-card__title">Portfolio pulse</h2>
+          <p className="section-card__subtitle">
+            Diversify confidently with actionable insights.
+          </p>
+        </div>
+        <button type="button" className="ghost-button" aria-label="Rebalance">
+          <IconArrowUpRight size={18} />
+        </button>
+      </div>
+
+      <div className="grid-2">
+        <section className="portfolio-metrics">
+          {metrics.map((metric) => (
+            <article key={metric.label}>
+              <p className="muted">{metric.label}</p>
+              <h3 className={metric.trend}>{metric.value}</h3>
+              <div className="progress-track" aria-hidden="true">
+                <div className="progress-fill" style={{ width: metric.trend === 'positive' ? '82%' : '46%' }} />
+              </div>
+            </article>
+          ))}
+        </section>
+        <section className="portfolio-holdings">
+          <header>
+            <h3>Top holdings</h3>
+            <button type="button" className="link-button">
+              View all
+              <IconChevronRight size={16} strokeWidth={1.8} />
+            </button>
+          </header>
+          <table className="table" role="grid">
+            <thead>
+              <tr>
+                <th align="left">Symbol</th>
+                <th align="left">Qty</th>
+                <th align="left">Avg</th>
+                <th align="left">LTP</th>
+                <th align="left">P&amp;L</th>
+              </tr>
+            </thead>
+            <tbody>
+              {holdings.map((holding) => (
+                <tr key={holding.symbol}>
+                  <td>
+                    <div className="symbol">
+                      <span>{holding.symbol}</span>
+                      <small>{holding.name}</small>
+                    </div>
+                  </td>
+                  <td>{holding.qty}</td>
+                  <td>{holding.avg}</td>
+                  <td>{holding.ltp}</td>
+                  <td className="positive">{holding.pnl}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ProfileTab.jsx
+++ b/frontend/src/components/ProfileTab.jsx
@@ -1,0 +1,76 @@
+import { IconDeviceMobile, IconLogout, IconSettings, IconShieldLock } from '@tabler/icons-react';
+
+const profileDetails = [
+  {
+    title: 'Account tier',
+    value: 'Prime Investor',
+    description: 'Enjoy priority support, zero AMC and enhanced charting.',
+  },
+  {
+    title: 'Linked accounts',
+    value: '4 broker connections',
+    description: 'Zerodha, Upstox, Angel One and Groww synced in real-time.',
+  },
+  {
+    title: '2FA status',
+    value: 'Secure with Authenticator',
+    description: 'Biometric fallback active, device trusted for 30 days.',
+  },
+  {
+    title: 'API usage',
+    value: '12,480 calls today',
+    description: 'Automations and webhooks are running efficiently.',
+  },
+];
+
+export default function ProfileTab() {
+  return (
+    <div className="section-card">
+      <div className="section-card__header">
+        <div>
+          <div className="tag">
+            <IconShieldLock size={14} />
+            Secure
+          </div>
+          <h2 className="section-card__title">Profile &amp; preferences</h2>
+          <p className="section-card__subtitle">
+            Manage accounts, devices and API keys across brokers.
+          </p>
+        </div>
+        <div className="profile-actions">
+          <button type="button" className="ghost-button" aria-label="Security settings">
+            <IconSettings size={18} />
+          </button>
+          <button type="button" className="ghost-button" aria-label="Logout">
+            <IconLogout size={18} />
+          </button>
+        </div>
+      </div>
+
+      <div className="profile-summary">
+        <article>
+          <h3>Ananya Sharma</h3>
+          <p className="muted">Client ID: BA12345</p>
+          <div className="tag tag--success">
+            <IconDeviceMobile size={14} />
+            Mobile verified
+          </div>
+        </article>
+        <div className="profile-summary__cta">
+          <button type="button">Switch to paper trading</button>
+          <button type="button" className="outline">Generate API token</button>
+        </div>
+      </div>
+
+      <div className="profile-grid">
+        {profileDetails.map((detail) => (
+          <article key={detail.title} className="profile-card">
+            <h4>{detail.title}</h4>
+            <p>{detail.value}</p>
+            <p>{detail.description}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/WatchlistTab.jsx
+++ b/frontend/src/components/WatchlistTab.jsx
@@ -1,0 +1,291 @@
+import { useMemo, useState } from 'react';
+import Fuse from 'fuse.js';
+import {
+  IconBolt,
+  IconChevronRight,
+  IconInfoCircle,
+  IconPlus,
+  IconSearch,
+  IconTrendingUp,
+} from '@tabler/icons-react';
+import { useLivePrices } from '../hooks/useLivePrices.js';
+
+const LIVE_COMPATIBLE_PATTERN = /^(NSE|BSE):/;
+
+const watchlistItems = [
+  {
+    symbol: 'NIFTY 50',
+    instrument: 'NSE:NIFTY 50',
+    name: 'NSE Index',
+    price: '22,200.60',
+    previousClose: 22110.15,
+    change: '+0.84%',
+    direction: 'up',
+    volume: '1.2M',
+    tags: ['all', 'nse', 'index'],
+  },
+  {
+    symbol: 'RELIANCE',
+    instrument: 'NSE:RELIANCE',
+    name: 'Reliance Industries',
+    price: '2,398.35',
+    previousClose: 2390.1,
+    change: '-0.42%',
+    direction: 'down',
+    volume: '845K',
+    tags: ['all', 'nse', 'equity', 'fno'],
+  },
+  {
+    symbol: 'TCS',
+    instrument: 'NSE:TCS',
+    name: 'Tata Consultancy',
+    price: '3,462.10',
+    previousClose: 3420.95,
+    change: '+1.26%',
+    direction: 'up',
+    volume: '412K',
+    tags: ['all', 'nse', 'equity', 'it'],
+  },
+  {
+    symbol: 'HDFCBANK',
+    instrument: 'NSE:HDFCBANK',
+    name: 'HDFC Bank',
+    price: '1,501.85',
+    previousClose: 1496.03,
+    change: '+0.32%',
+    direction: 'up',
+    volume: '615K',
+    tags: ['all', 'nse', 'equity', 'banking'],
+  },
+  {
+    symbol: 'SBIN',
+    instrument: 'BSE:SBIN',
+    name: 'State Bank of India',
+    price: '821.10',
+    previousClose: 816.4,
+    change: '+0.58%',
+    direction: 'up',
+    volume: '1.9M',
+    tags: ['all', 'bse', 'equity', 'banking'],
+  },
+  {
+    symbol: 'NIFTY FIN',
+    instrument: 'NSE:NIFTY FIN SERVICE',
+    name: 'Nifty Financial Services',
+    price: '21,342.25',
+    previousClose: 21210.33,
+    change: '-0.24%',
+    direction: 'down',
+    volume: '362K',
+    tags: ['all', 'nse', 'index', 'fno'],
+  },
+  {
+    symbol: 'BTC-INR',
+    instrument: 'CRYPTO:BTC-INR',
+    name: 'Bitcoin',
+    price: '5,841,220.00',
+    previousClose: 5798220,
+    change: '+2.42%',
+    direction: 'up',
+    volume: '32.1K',
+    tags: ['all', 'crypto'],
+  },
+];
+
+const quickFilters = [
+  { label: 'All', value: 'all' },
+  { label: 'NSE', value: 'nse' },
+  { label: 'BSE', value: 'bse' },
+  { label: 'F&O', value: 'fno' },
+  { label: 'Crypto', value: 'crypto' },
+];
+
+const fuseOptions = {
+  includeScore: true,
+  threshold: 0.32,
+  keys: [
+    { name: 'symbol', weight: 0.6 },
+    { name: 'name', weight: 0.4 },
+  ],
+};
+
+const formatPrice = (value) =>
+  Number(value).toLocaleString('en-IN', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+const formatChange = (percent) =>
+  `${percent > 0 ? '+' : ''}${percent.toFixed(2)}%`;
+
+export default function WatchlistTab() {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedFilter, setSelectedFilter] = useState('all');
+  const fuse = useMemo(() => new Fuse(watchlistItems, fuseOptions), []);
+  const searchedItems = useMemo(() => {
+    if (!searchQuery.trim()) {
+      return watchlistItems;
+    }
+    return fuse.search(searchQuery).map((result) => result.item);
+  }, [fuse, searchQuery]);
+
+  const filteredItems = useMemo(() => {
+    if (selectedFilter === 'all') {
+      return searchedItems;
+    }
+    return searchedItems.filter((item) => item.tags?.includes(selectedFilter));
+  }, [searchedItems, selectedFilter]);
+
+  const liveEligibleInstruments = useMemo(
+    () =>
+      filteredItems
+        .map((item) => item.instrument)
+        .filter((instrument) => LIVE_COMPATIBLE_PATTERN.test(instrument ?? '')),
+    [filteredItems],
+  );
+
+  const { prices, status, error } = useLivePrices(liveEligibleInstruments, {
+    refreshInterval: 4000,
+    simulateOnError: true,
+  });
+
+  const enrichedItems = filteredItems.map((item) => {
+    const livePrice = prices[item.instrument];
+    if (livePrice == null) {
+      return item;
+    }
+
+    const priceNumber = Number(livePrice);
+    const changePercent = item.previousClose
+      ? ((priceNumber - item.previousClose) / item.previousClose) * 100
+      : null;
+    return {
+      ...item,
+      price: formatPrice(priceNumber),
+      change: changePercent != null ? formatChange(changePercent) : item.change,
+      direction: changePercent != null && changePercent < 0 ? 'down' : 'up',
+    };
+  });
+
+  const indicatorState = error
+    ? 'error'
+    : status === 'degraded'
+    ? 'degraded'
+    : status === 'loading'
+    ? 'pending'
+    : status === 'success'
+    ? 'active'
+    : 'idle';
+
+  const liveStatusText = (() => {
+    if (error) return 'Live feed unavailable';
+    switch (status) {
+      case 'loading':
+        return 'Refreshing prices…';
+      case 'degraded':
+        return 'Simulating prices while reconnecting';
+      case 'success':
+        return 'Streaming live prices';
+      default:
+        return 'Price feed idle';
+    }
+  })();
+
+  return (
+    <div className="section-card">
+      <div className="section-card__header">
+        <div>
+          <div className="tag">
+            <IconTrendingUp size={14} />
+            Live Markets
+          </div>
+          <h2 className="section-card__title">Your smart watchlists</h2>
+          <p className="section-card__subtitle">
+            Track indices, stocks &amp; derivatives with lightning-fast updates.
+          </p>
+        </div>
+        <button type="button" className="ghost-button" aria-label="Create watchlist">
+          <IconPlus size={18} />
+        </button>
+      </div>
+
+      <div className="watchlist-toolbar">
+        <div className="watchlist-search">
+          <IconSearch aria-hidden size={16} />
+          <input
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            type="search"
+            placeholder="Search by symbol or name"
+            aria-label="Search instruments"
+          />
+        </div>
+        <div className={`live-indicator live-indicator--${indicatorState}`} role="status" aria-live="polite">
+          <IconBolt size={14} />
+          <span>{liveStatusText}</span>
+        </div>
+      </div>
+
+      {error && (
+        <div className="alert alert--error" role="alert">
+          <IconInfoCircle size={16} aria-hidden />
+          <div>
+            <strong>Realtime Zerodha feed is unavailable.</strong>
+            <p>
+              We are showing the latest known prices with smart simulation so you can continue
+              evaluating trades while the connection recovers.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="quick-filters">
+        {quickFilters.map((filter) => {
+          const isActive = selectedFilter === filter.value;
+          return (
+            <button
+              key={filter.value}
+              type="button"
+              className={`chip ${isActive ? 'chip--active' : ''}`}
+              onClick={() => setSelectedFilter(filter.value)}
+              aria-pressed={isActive}
+            >
+              {filter.label}
+          </button>
+          );
+        })}
+      </div>
+
+      {enrichedItems.length === 0 ? (
+        <div className="watchlist-empty" role="status" aria-live="polite">
+          <strong>No instruments match your filters.</strong>
+          <p>Try clearing the search or switching segments to keep trading opportunities in view.</p>
+        </div>
+      ) : (
+        <div className="watchlist-grid">
+          {enrichedItems.map((item) => (
+            <article key={item.symbol} className="watchlist-card">
+              <header>
+                <div>
+                  <h3>{item.symbol}</h3>
+                  <p>{item.name}</p>
+                </div>
+                <IconChevronRight size={18} strokeWidth={1.8} />
+              </header>
+              <div className="watchlist-card__body">
+                <strong>{item.price}</strong>
+                <span className={item.direction === 'up' ? 'positive' : 'negative'}>
+                  {item.change}
+                </span>
+              </div>
+              <footer>
+                <span className="muted">Volume</span>
+                <span>{item.volume}</span>
+              </footer>
+            </article>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useLivePrices.js
+++ b/frontend/src/hooks/useLivePrices.js
@@ -1,0 +1,131 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const DEFAULT_REFRESH_INTERVAL = 5000;
+const ZERODHA_LTP_URL = 'https://api.kite.trade/quote/ltp';
+const MAX_JITTER_PERCENT = 0.35;
+
+const serializeInstruments = (instruments = []) => instruments.slice().sort().join('|');
+
+export function useLivePrices(
+  instruments,
+  { token, refreshInterval = DEFAULT_REFRESH_INTERVAL, simulateOnError = false } = {},
+) {
+  const [prices, setPrices] = useState({});
+  const [status, setStatus] = useState('idle');
+  const [error, setError] = useState(null);
+  const instrumentsKey = useMemo(() => serializeInstruments(instruments), [instruments]);
+  const abortRef = useRef();
+  const lastSuccessfulRef = useRef({});
+
+  useEffect(() => {
+    if (!instruments?.length) {
+      setPrices({});
+      setStatus('idle');
+      setError(null);
+      return () => {};
+    }
+
+    let mounted = true;
+
+    const fetchPrices = async () => {
+      setStatus('loading');
+
+      const params = new URLSearchParams();
+      instruments.forEach((instrument) => {
+        if (instrument) {
+          params.append('i', instrument);
+        }
+      });
+
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const response = await fetch(`${ZERODHA_LTP_URL}?${params.toString()}`, {
+          headers: {
+            'X-Kite-Version': '3',
+            ...(token ? { Authorization: `token ${token}` } : {}),
+          },
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`Zerodha quote request failed with status ${response.status}`);
+        }
+
+        const payload = await response.json();
+        if (!mounted) return;
+
+        const nextPrices = {};
+        Object.entries(payload?.data ?? {}).forEach(([instrumentKey, value]) => {
+          const lastPrice = value?.last_price ?? null;
+          if (lastPrice != null) {
+            nextPrices[instrumentKey] = lastPrice;
+          }
+        });
+
+        if (Object.keys(nextPrices).length === 0) {
+          throw new Error('Zerodha quote response did not include last prices.');
+        }
+
+        setPrices(nextPrices);
+        setStatus('success');
+        setError(null);
+        lastSuccessfulRef.current = nextPrices;
+      } catch (fetchError) {
+        if (!mounted || controller.signal.aborted) {
+          return;
+        }
+        console.warn('[useLivePrices] Falling back to cached data:', fetchError);
+        setError(fetchError);
+
+        if (simulateOnError) {
+          setPrices((previousPrices) => {
+            const source = Object.keys(previousPrices).length
+              ? previousPrices
+              : lastSuccessfulRef.current;
+
+            if (!source || Object.keys(source).length === 0) {
+              return previousPrices;
+            }
+
+            const simulated = {};
+            Object.entries(source).forEach(([instrumentKey, lastPrice]) => {
+              const numericPrice = Number(lastPrice);
+              if (Number.isNaN(numericPrice)) {
+                simulated[instrumentKey] = lastPrice;
+                return;
+              }
+              const direction = Math.random() > 0.5 ? 1 : -1;
+              const jitterPercent = Math.random() * MAX_JITTER_PERCENT;
+              const delta = numericPrice * (jitterPercent / 100) * direction;
+              const nextPrice = Math.max(numericPrice + delta, 0);
+              simulated[instrumentKey] = Number(nextPrice.toFixed(2));
+            });
+            return simulated;
+          });
+          setStatus('degraded');
+        } else {
+          setStatus('error');
+        }
+      }
+    };
+
+    fetchPrices();
+    const intervalId = setInterval(fetchPrices, refreshInterval);
+
+    return () => {
+      mounted = false;
+      clearInterval(intervalId);
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+    };
+  }, [instrumentsKey, refreshInterval, token]);
+
+  return { prices, status, error };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,26 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0f172a;
+  color: #0f172a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  background: linear-gradient(180deg, #0f172a 0%, #020617 100%);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+#root {
+  min-height: 100vh;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- add richer instrument metadata, segment filtering, and graceful empty states in the watchlist
- surface live feed health with dynamic indicators and alerts while keeping the UI accessible
- harden the Zerodha polling hook with optional simulated fallbacks during outages

## Testing
- npm install --prefix frontend *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e14fbdd53c8331a7899048ba21863b